### PR TITLE
Reference Generator

### DIFF
--- a/Sources/xcodeproj/PBXAggregateTarget.swift
+++ b/Sources/xcodeproj/PBXAggregateTarget.swift
@@ -38,7 +38,7 @@ public struct PBXAggregateTarget: PBXTarget {
     /// Initializes the aggregate target with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - buildConfigurationList: target build configuration list (reference).
     ///   - buildPhases: target build phases.
     ///   - buildRules: target build rules.
@@ -47,7 +47,7 @@ public struct PBXAggregateTarget: PBXTarget {
     ///   - productName: target product name.
     ///   - productReference: target product reference.
     ///   - productType: target product type.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 buildConfigurationList: String,
                 buildPhases: [String],
                 buildRules: [String],
@@ -56,7 +56,7 @@ public struct PBXAggregateTarget: PBXTarget {
                 productName: String? = nil,
                 productReference: String? = nil,
                 productType: PBXProductType? = nil) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXAggregateTarget.self, name)
         self.buildConfigurationList = buildConfigurationList
         self.buildPhases = buildPhases
         self.buildRules = buildRules

--- a/Sources/xcodeproj/PBXBuildFile.swift
+++ b/Sources/xcodeproj/PBXBuildFile.swift
@@ -23,13 +23,13 @@ public struct PBXBuildFile: ProjectElement {
     /// Initiazlies the build file with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - fileRef: build file reference.
     ///   - settings: build file settings.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 fileRef: String,
                 settings: [String: Any]? = nil) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXBuildFile.self, fileRef)
         self.fileRef = fileRef
         self.settings = settings
     }

--- a/Sources/xcodeproj/PBXContainerItemProxy.swift
+++ b/Sources/xcodeproj/PBXContainerItemProxy.swift
@@ -28,16 +28,16 @@ public struct PBXContainerItemProxy {
     /// Initializes the container item proxy with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: reference to the element.
+    ///   - reference: reference to the element. Will be automatically generated if not specified
     ///   - containerPortal: reference to the container portal.
     ///   - remoteGlobalIDString: reference to the remote global ID.
     ///   - remoteInfo: remote info.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 containerPortal: String,
                 remoteGlobalIDString: String,
                 proxyType: ProxyType = .nativeTarget,
                 remoteInfo: String? = nil) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXContainerItemProxy.self, containerPortal + remoteGlobalIDString)
         self.containerPortal = containerPortal
         self.remoteGlobalIDString = remoteGlobalIDString
         self.remoteInfo = remoteInfo

--- a/Sources/xcodeproj/PBXCopyFilesBuildPhase.swift
+++ b/Sources/xcodeproj/PBXCopyFilesBuildPhase.swift
@@ -44,19 +44,21 @@ public struct PBXCopyFilesBuildPhase {
     /// Initializes the copy files build phase with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: reference.
+    ///   - reference: reference. Will be automatically generated if not specified
     ///   - dstPath: destination path.
     ///   - dstSubfolderSpec: destination subfolder spec.
     ///   - buildActionMask: build action mask.
     ///   - files: files to copy.
     ///   - runOnlyForDeploymentPostprocessing: run only for deployment post processing.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 dstPath: String,
                 dstSubfolderSpec: SubFolder,
                 buildActionMask: UInt = 2147483647,
                 files: Set<String> = [],
                 runOnlyForDeploymentPostprocessing: UInt = 0) {
-        self.reference = reference
+        self.reference = reference ??
+            ReferenceGenerator.shared.generateReference(PBXCopyFilesBuildPhase.self,
+                                                        dstPath + dstSubfolderSpec.hashValue.description + files.joined())
         self.dstPath = dstPath
         self.buildActionMask = buildActionMask
         self.dstSubfolderSpec = dstSubfolderSpec

--- a/Sources/xcodeproj/PBXFileElement.swift
+++ b/Sources/xcodeproj/PBXFileElement.swift
@@ -23,14 +23,14 @@ public struct PBXFileElement {
     /// Initializes the file element with its properties.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - sourceTree: file source tree.
     ///   - name: file name.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 sourceTree: PBXSourceTree,
                 path: String,
                 name: String) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXFileElement.self, sourceTree.rawValue + path + name)
         self.sourceTree = sourceTree
         self.path = path
         self.name = name

--- a/Sources/xcodeproj/PBXFileReference.swift
+++ b/Sources/xcodeproj/PBXFileReference.swift
@@ -34,7 +34,7 @@ public struct PBXFileReference {
     
     // MARK: - Init
     
-    public init(reference: String,
+    public init(reference: String? = nil,
                 sourceTree: PBXSourceTree,
                 name: String? = nil,
                 fileEncoding: Int? = nil,
@@ -43,6 +43,8 @@ public struct PBXFileReference {
                 path: String? = nil,
                 includeInIndex: Int? = nil) {
         self.reference = reference
+            ?? ReferenceGenerator.shared.generateReference(PBXFileReference.self,
+                                                           sourceTree.rawValue + String(describing: name) + String(describing: path))
         self.fileEncoding = fileEncoding
         self.explicitFileType = explicitFileType
         self.lastKnownFileType = lastKnownFileType

--- a/Sources/xcodeproj/PBXFrameworksBuildPhase.swift
+++ b/Sources/xcodeproj/PBXFrameworksBuildPhase.swift
@@ -23,14 +23,14 @@ public struct PBXFrameworksBuildPhase {
     /// Initializes the frameworks build phase with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - files: frameworks build phase files.
     ///   - runOnlyForDeploymentPostprocessing: run only for deployment pos processing value.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 files: Set<String>,
                 runOnlyForDeploymentPostprocessing: UInt,
                 buildActionMask: Int = 2147483647) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXFrameworksBuildPhase.self, files.joined())
         self.files = files
         self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing
         self.buildActionMask = buildActionMask

--- a/Sources/xcodeproj/PBXGroup.swift
+++ b/Sources/xcodeproj/PBXGroup.swift
@@ -26,17 +26,17 @@ public struct PBXGroup {
     /// Initializes the group with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - children: group children.
     ///   - sourceTree: group source tree.
     ///   - name: group name.
     ///   - path: group path.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 children: [String],
                 sourceTree: PBXSourceTree,
                 name: String? = nil,
                 path: String? = nil) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXGroup.self, String(describing: name) + String(describing: path))
         self.children = children
         self.name = name
         self.sourceTree = sourceTree

--- a/Sources/xcodeproj/PBXHeadersBuildPhase.swift
+++ b/Sources/xcodeproj/PBXHeadersBuildPhase.swift
@@ -74,11 +74,11 @@ extension PBXHeadersBuildPhase: ProjectElement {
     
     public var hashValue: Int { return self.reference.hashValue }
     
-    public init(reference: String,
+    public init(reference: String? = nil,
                 buildActionMask: UInt = 2147483647,
                 files: Set<String> = Set(),
                 runOnlyForDeploymentPostprocessing: UInt = 0) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXHeadersBuildPhase.self, files.joined())
         self.buildActionMask = buildActionMask
         self.files = files
         self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing

--- a/Sources/xcodeproj/PBXNativeTarget.swift
+++ b/Sources/xcodeproj/PBXNativeTarget.swift
@@ -36,7 +36,7 @@ public struct PBXNativeTarget: PBXTarget {
     /// Initializes the native target with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - buildConfigurationList: target build configuration list.
     ///   - buildPhases: target build phases.
     ///   - buildRules: target build rules.
@@ -45,7 +45,7 @@ public struct PBXNativeTarget: PBXTarget {
     ///   - productName: target product name.
     ///   - productReference: target product reference.
     ///   - productType: target product type.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 buildConfigurationList: String,
                 buildPhases: [String],
                 buildRules: [String],
@@ -54,7 +54,7 @@ public struct PBXNativeTarget: PBXTarget {
                 productName: String? = nil,
                 productReference: String? = nil,
                 productType: PBXProductType? = nil) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXNativeTarget.self, name + String(describing: productType))
         self.buildConfigurationList = buildConfigurationList
         self.buildPhases = buildPhases
         self.buildRules = buildRules

--- a/Sources/xcodeproj/PBXProj.swift
+++ b/Sources/xcodeproj/PBXProj.swift
@@ -182,25 +182,3 @@ extension PBXProj {
     }
     
 }
-
-// MARK: - PBXProj Extension (UUID Generation)
-
-public extension PBXProj {
-    
-    /// Returns a valid UUID for new elements.
-    ///
-    /// - Parameter element: project element class.
-    /// - Returns: UUID available to be used.
-    public func generateUUID<T: ProjectElement>(for element: T.Type) -> String {
-        var uuid: String = ""
-        var counter: UInt = 0
-        let random: String = String.random()
-        let className: String = String(describing: T.self).hash.description
-        repeat {
-            counter += 1
-            uuid = String(format: "%08X%08X%08X", className, random, counter)
-        } while(self.objects.map({$0.reference}).contains(uuid))
-        return uuid
-    }
-    
-}

--- a/Sources/xcodeproj/PBXProject.swift
+++ b/Sources/xcodeproj/PBXProject.swift
@@ -52,7 +52,7 @@ public struct PBXProject: ProjectElement, PlistSerializable {
     /// Initializes the project with its attributes
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - buildConfigurationList: project build configuration list.
     ///   - compatibilityVersion: project compatibility version.
     ///   - mainGroup: project main group.
@@ -65,7 +65,7 @@ public struct PBXProject: ProjectElement, PlistSerializable {
     ///   - projectRoot: project root.
     ///   - targets: project targets.
     ///   - attributes: project attributes.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 buildConfigurationList: String,
                 compatibilityVersion: String,
                 mainGroup: String,
@@ -78,7 +78,7 @@ public struct PBXProject: ProjectElement, PlistSerializable {
                 projectRoot: String? = nil,
                 targets: [String] = [],
                 attributes: [String: Any] = [:]) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXProject.self, "project")
         self.buildConfigurationList = buildConfigurationList
         self.compatibilityVersion = compatibilityVersion
         self.mainGroup = mainGroup

--- a/Sources/xcodeproj/PBXResourcesBuildPhase.swift
+++ b/Sources/xcodeproj/PBXResourcesBuildPhase.swift
@@ -19,14 +19,14 @@ public struct PBXResourcesBuildPhase {
     /// Initializes the resources build phase with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - files: element files.
     ///   - runOnlyForDeploymentPostprocessing: run only for deployment post processing value.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 files: Set<String>,
                 runOnlyForDeploymentPostprocessing: Int = 0,
                 buildActionMask: Int = 2147483647) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXResourcesBuildPhase.self, files.joined())
         self.files = files
         self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing
         self.buildActionMask = buildActionMask

--- a/Sources/xcodeproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcodeproj/PBXShellScriptBuildPhase.swift
@@ -39,14 +39,14 @@ public struct PBXShellScriptBuildPhase {
     /// Initializes the shell script build phase with its attributes.
     ///
     /// - Parameters:
-    ///   - reference: references.
+    ///   - reference: reference. Will be automatically generated if not specified
     ///   - files: shell script files.
     ///   - inputPaths: input paths.
     ///   - outputPaths: output paths.
     ///   - shellPath: shell path.
     ///   - shellScript: shell script.
     ///   - buildActionMask: build action mask.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 files: Set<String>,
                 name: String,
                 inputPaths: Set<String>,
@@ -54,7 +54,7 @@ public struct PBXShellScriptBuildPhase {
                 shellPath: String,
                 shellScript: String?,
                 buildActionMask: Int = 2147483647) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXShellScriptBuildPhase.self, name)
         self.files = files
         self.name = name
         self.inputPaths = inputPaths

--- a/Sources/xcodeproj/PBXSourcesBuildPhase.swift
+++ b/Sources/xcodeproj/PBXSourcesBuildPhase.swift
@@ -26,11 +26,11 @@ public struct PBXSourcesBuildPhase: ProjectElement, PlistSerializable {
     /// Initializes the build phase with the reference and the files.
     ///
     /// - Parameters:
-    ///   - reference: build phase reference.
+    ///   - reference: build phase reference. Will be automatically generated if not specified
     ///   - files: build phase files.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 files: Set<String>) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXSourcesBuildPhase.self, files.joined())
         self.files = files
     }
     

--- a/Sources/xcodeproj/PBXTargetDependency.swift
+++ b/Sources/xcodeproj/PBXTargetDependency.swift
@@ -23,13 +23,13 @@ public struct PBXTargetDependency: ProjectElement, Hashable, PlistSerializable {
     /// Initializes the target dependency.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - target: element target.
     ///   - targetProxy: element target proxy.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 target: String,
                 targetProxy: String) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXTargetDependency.self, target + targetProxy)
         self.target = target
         self.targetProxy = targetProxy
     }

--- a/Sources/xcodeproj/PBXVariantGroup.swift
+++ b/Sources/xcodeproj/PBXVariantGroup.swift
@@ -26,15 +26,15 @@ public struct PBXVariantGroup: ProjectElement, PlistSerializable {
     /// Initializes the PBXVariantGroup with its values.
     ///
     /// - Parameters:
-    ///   - reference: variant group reference.
+    ///   - reference: variant group reference. Will be automatically generated if not specified
     ///   - children: group children references.
     ///   - name: name of the variant group
     ///   - sourceTree: the group source tree.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 children: Set<String>,
                 name: String,
                 sourceTree: PBXSourceTree) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(PBXVariantGroup.self, name)
         self.children = children
         self.name = name
         self.sourceTree = sourceTree

--- a/Sources/xcodeproj/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/ReferenceGenerator.swift
@@ -1,0 +1,45 @@
+//
+//  ReferenceGenerator.swift
+//  xcodeproj
+//
+//  Created by Yonas Kolb on 31/7/17.
+//
+//
+
+import Foundation
+
+
+/// Generates unique reference
+public class ReferenceGenerator {
+
+    private var references: Set<String> = []
+
+    public init() {
+
+    }
+
+    /// This resets all the cached references
+    public func reset() {
+        references = []
+    }
+
+
+    /// This generates a unique 20 character reference id to be used in ProjectElement.reference
+    ///
+    /// - Parameters:
+    ///   - element: The type of Project Element to generate for
+    ///   - id: some string value that uniquely defines the object. It doesn't have to be completely unique as duplicates will be handled, but it provides deterministic references
+    /// - Returns: The generated unique reference
+    public func generateReference<T: ProjectElement>(_ element: T.Type, _ id: String) -> String {
+        var reference = ""
+        var counter = 0
+        let className = String(describing: T.self).replacingOccurrences(of: "PBX", with: "")
+        let classAcronym = String(className.characters.filter { String($0).lowercased() != String($0) })
+        let stringID = String(abs(id.hashValue).description.characters.prefix(18 - classAcronym.characters.count))
+        repeat {
+            counter += 1
+            reference = "\(classAcronym)\(stringID)\(String(format: "%02d", counter))"
+        } while (references.contains(reference))
+        references.insert(reference)
+        return reference
+    }}

--- a/Sources/xcodeproj/ReferenceGenerator.swift
+++ b/Sources/xcodeproj/ReferenceGenerator.swift
@@ -1,16 +1,9 @@
-//
-//  ReferenceGenerator.swift
-//  xcodeproj
-//
-//  Created by Yonas Kolb on 31/7/17.
-//
-//
-
 import Foundation
 
-
-/// Generates unique reference
+/// Generates unique deterministic reference. Must be reset if generating for a new project if totally deterministc references are wanted
 public class ReferenceGenerator {
+
+    static let shared = ReferenceGenerator()
 
     private var references: Set<String> = []
 
@@ -18,27 +11,27 @@ public class ReferenceGenerator {
 
     }
 
-    /// This resets all the cached references
+    /// This resets all the cached references to again make them deterministic
     public func reset() {
         references = []
     }
-
 
     /// This generates a unique 20 character reference id to be used in ProjectElement.reference
     ///
     /// - Parameters:
     ///   - element: The type of Project Element to generate for
-    ///   - id: some string value that uniquely defines the object. It doesn't have to be completely unique as duplicates will be handled, but it provides deterministic references
+    ///   - uniqueId: some string value that uniquely defines the object.
+    ///         It doesn't have to be completely unique as duplicates will be handled, but it provides deterministic references
     /// - Returns: The generated unique reference
-    public func generateReference<T: ProjectElement>(_ element: T.Type, _ id: String) -> String {
+    public func generateReference<T: ProjectElement>(_ element: T.Type, _ uniqueId: String) -> String {
         var reference = ""
         var counter = 0
         let className = String(describing: T.self).replacingOccurrences(of: "PBX", with: "")
         let classAcronym = String(className.characters.filter { String($0).lowercased() != String($0) })
-        let stringID = String(abs(id.hashValue).description.characters.prefix(18 - classAcronym.characters.count))
+        let uniqueHash = String(abs(uniqueId.hashValue).description.characters.prefix(18 - classAcronym.characters.count))
         repeat {
             counter += 1
-            reference = "\(classAcronym)\(stringID)\(String(format: "%02d", counter))"
+            reference = "\(classAcronym)\(uniqueHash)\(String(format: "%02d", counter))"
         } while (references.contains(reference))
         references.insert(reference)
         return reference

--- a/Sources/xcodeproj/XCBuildConfiguration.swift
+++ b/Sources/xcodeproj/XCBuildConfiguration.swift
@@ -23,15 +23,15 @@ public struct XCBuildConfiguration {
     /// Initializes a build configuration.
     ///
     /// - Parameters:
-    ///   - reference: build configuration reference.
+    ///   - reference: build configuration reference. Will be automatically generated if not specified
     ///   - name: build configuration name.
     ///   - baseConfigurationReference: reference to the base configuration.
     ///   - buildSettings: dictionary that contains the build settings for this configuration.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 name: String,
                 baseConfigurationReference: String? = nil,
                 buildSettings: BuildSettings = [:]) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(XCBuildConfiguration.self, name)
         self.baseConfigurationReference = baseConfigurationReference
         self.buildSettings = buildSettings
         self.name = name

--- a/Sources/xcodeproj/XCConfigurationList.swift
+++ b/Sources/xcodeproj/XCConfigurationList.swift
@@ -23,15 +23,15 @@ public struct XCConfigurationList {
     /// Initializes the element with its properties.
     ///
     /// - Parameters:
-    ///   - reference: element reference.
+    ///   - reference: element reference. Will be automatically generated if not specified
     ///   - buildConfigurations: element build configurations.
     ///   - defaultConfigurationName: element default configuration name.
     ///   - defaultConfigurationIsVisible: default configuration is visible.
-    public init(reference: String,
+    public init(reference: String? = nil,
                 buildConfigurations: Set<String>,
                 defaultConfigurationName: String,
                 defaultConfigurationIsVisible: UInt = 0) {
-        self.reference = reference
+        self.reference = reference ?? ReferenceGenerator.shared.generateReference(XCConfigurationList.self, buildConfigurations.joined())
         self.buildConfigurations = buildConfigurations
         self.defaultConfigurationName = defaultConfigurationName
         self.defaultConfigurationIsVisible = defaultConfigurationIsVisible

--- a/Tests/xcodeprojTests/ReferenceGeneratorSpec.swift
+++ b/Tests/xcodeprojTests/ReferenceGeneratorSpec.swift
@@ -1,0 +1,45 @@
+import Foundation
+import xcodeproj
+import XCTest
+
+final class ReferenceGeneratorSpec: XCTestCase {
+
+    func test_generates_references() {
+        let generator = ReferenceGenerator()
+        let reference = generator.generateReference(PBXBuildFile.self, "file.swift")
+
+        XCTAssert(reference.characters.count == 20)
+        XCTAssertTrue(reference.hasPrefix("BF"))
+        XCTAssertTrue(reference.hasSuffix("01"))
+    }
+
+    func test_generates_handles_duplicate_ids() {
+        let generator = ReferenceGenerator()
+        let reference1 = generator.generateReference(PBXBuildFile.self, "file.swift")
+        let reference2 = generator.generateReference(PBXBuildFile.self, "file.swift")
+
+        XCTAssert(reference1 != reference2)
+        XCTAssertTrue(reference2.hasSuffix("02"))
+    }
+
+    func test_generates_resets_uniqueness() {
+        let generator = ReferenceGenerator()
+        let reference1 = generator.generateReference(PBXBuildFile.self, "file.swift")
+        generator.reset()
+        let reference2 = generator.generateReference(PBXBuildFile.self, "file.swift")
+
+        XCTAssert(reference1 == reference2)
+    }
+
+    func test_generates_unique_ids() {
+        let generator = ReferenceGenerator()
+        let reference1 = generator.generateReference(PBXBuildFile.self, "file1.swift")
+        let reference2 = generator.generateReference(PBXBuildFile.self, "file2.swift")
+        let reference3 = generator.generateReference(PBXFileReference.self, "file1.swift")
+
+        XCTAssert(reference1 != reference2)
+        XCTAssert(reference1 != reference3)
+        XCTAssert(reference2 != reference3)
+    }
+
+}

--- a/Tests/xcodeprojTests/ReferenceGeneratorSpec.swift
+++ b/Tests/xcodeprojTests/ReferenceGeneratorSpec.swift
@@ -31,7 +31,7 @@ final class ReferenceGeneratorSpec: XCTestCase {
         XCTAssert(reference1 == reference2)
     }
 
-    func test_generates_unique_ids() {
+    func test_generates_unique_references() {
         let generator = ReferenceGenerator()
         let reference1 = generator.generateReference(PBXBuildFile.self, "file1.swift")
         let reference2 = generator.generateReference(PBXBuildFile.self, "file2.swift")
@@ -40,6 +40,21 @@ final class ReferenceGeneratorSpec: XCTestCase {
         XCTAssert(reference1 != reference2)
         XCTAssert(reference1 != reference3)
         XCTAssert(reference2 != reference3)
+    }
+
+    func test_generates_automatic_references() {
+
+        let fileRef = PBXFileReference(sourceTree: .group, name: "File", path: "file.swift")
+        let buildFile1 = PBXBuildFile(fileRef: fileRef.reference)
+        let buildFile2 = PBXBuildFile(fileRef: fileRef.reference)
+
+        XCTAssert(fileRef.reference.characters.count == 20)
+        XCTAssert(buildFile1.reference.characters.count == 20)
+        XCTAssert(buildFile2.reference.characters.count == 20)
+        XCTAssert(fileRef.reference.hasPrefix("FR"))
+        XCTAssert(buildFile1.reference.hasPrefix("BF"))
+        XCTAssert(buildFile2.reference.hasPrefix("BF"))
+        XCTAssert(buildFile1.reference != buildFile2.reference)
     }
 
 }

--- a/xcodeproj.xcodeproj/project.pbxproj
+++ b/xcodeproj.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CC2DB84C1F2F4CDF00B4B0FA /* ReferenceGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2DB84B1F2F4CDF00B4B0FA /* ReferenceGenerator.swift */; };
+		CC2DB84E1F2F4E7F00B4B0FA /* ReferenceGeneratorSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2DB84D1F2F4E7F00B4B0FA /* ReferenceGeneratorSpec.swift */; };
 		OBJ_165 /* Case.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_142 /* Case.swift */; };
 		OBJ_166 /* Context.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_143 /* Context.swift */; };
 		OBJ_167 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_144 /* Expectation.swift */; };
@@ -364,6 +366,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CC2DB84B1F2F4CDF00B4B0FA /* ReferenceGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferenceGenerator.swift; sourceTree = "<group>"; };
+		CC2DB84D1F2F4E7F00B4B0FA /* ReferenceGeneratorSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReferenceGeneratorSpec.swift; sourceTree = "<group>"; };
 		OBJ_10 /* BuildSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildSettings.swift; sourceTree = "<group>"; };
 		OBJ_100 /* Data+Unbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Unbox.swift"; sourceTree = "<group>"; };
 		OBJ_101 /* DateFormatter+Unbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Unbox.swift"; sourceTree = "<group>"; };
@@ -662,7 +666,7 @@
 			path = Sources/xcodeprojprotocols;
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -674,7 +678,6 @@
 				OBJ_88 /* Dependencies */,
 				OBJ_150 /* Products */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_50 /* Tests */ = {
@@ -729,6 +732,7 @@
 				OBJ_82 /* XCSchemeSpec.swift */,
 				OBJ_83 /* XCWorkspaceDataSpec.swift */,
 				OBJ_84 /* XCWorkspaceSpec.swift */,
+				CC2DB84D1F2F4E7F00B4B0FA /* ReferenceGeneratorSpec.swift */,
 			);
 			name = xcodeprojTests;
 			path = Tests/xcodeprojTests;
@@ -782,6 +786,7 @@
 				OBJ_41 /* XCSharedData.swift */,
 				OBJ_42 /* XCWorkspace.swift */,
 				OBJ_43 /* XCWorkspaceData.swift */,
+				CC2DB84B1F2F4CDF00B4B0FA /* ReferenceGenerator.swift */,
 			);
 			name = xcodeproj;
 			path = Sources/xcodeproj;
@@ -1060,7 +1065,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_150 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1176,6 +1181,7 @@
 				OBJ_253 /* PBXCopyFilesBuildPhase.swift in Sources */,
 				OBJ_254 /* PBXFileElement.swift in Sources */,
 				OBJ_255 /* PBXFileReference.swift in Sources */,
+				CC2DB84C1F2F4CDF00B4B0FA /* ReferenceGenerator.swift in Sources */,
 				OBJ_256 /* PBXFrameworksBuildPhase.swift in Sources */,
 				OBJ_257 /* PBXGroup.swift in Sources */,
 				OBJ_258 /* PBXHeadersBuildPhase.swift in Sources */,
@@ -1236,6 +1242,7 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_351 /* BuildPhaseSpecs.swift in Sources */,
+				CC2DB84E1F2F4E7F00B4B0FA /* ReferenceGeneratorSpec.swift in Sources */,
 				OBJ_352 /* Fixtures.swift in Sources */,
 				OBJ_353 /* PBXAggregateTargetSpec.swift in Sources */,
 				OBJ_354 /* PBXBuildFileSpec.swift in Sources */,


### PR DESCRIPTION
Fixes #31, Fixes #29 

This adds a new `ReferenceGenerator` class which automatically creates deterministic references for ProjectElement's

There are a few things in this PR:

- removal of Common Crypto
- addition of ReferenceGenerator
- changed `reference: String` to an optional parameter in Project Element initializers. If it is not specified, then reference is automatically generated via a default ReferenceGenerator
- tests

This enabled the following features:

- linux support with the removal of Common Crypto
- fixes old generator not generating unique references
- deterministic references
- automatic references when initializing objects

Things to consider:
- should `ProjectElement.reference` be renamed `ProjectElement.id`?
- the automatic generation in the inits is happening via a shared `ReferenceGenerator`. When should this be `reset()` and cleared of cached references, for both memory (negligible) and for determinism. If it's a manual process left up to the user, how is this documented?
- should references be initialized with a totally random and guaranteed string and then only on write make them deterministic. This might solve the above issue