### PR TITLE
Fix pbxproj comment for buildConfigurationList

### DIFF
--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -102,7 +102,7 @@ public class PBXProject: PBXObject, Hashable {
     /// - Throws: throws an error in case any of the propeties are missing or they have the wrong type.
     public override init(reference: String, dictionary: [String: Any]) throws {
         let unboxer = Unboxer(dictionary: dictionary)
-        self.name = try unboxer.unbox(key: "name")
+        self.name = (try? unboxer.unbox(key: "name")) ?? ""
         self.buildConfigurationList = try unboxer.unbox(key: "buildConfigurationList")
         self.compatibilityVersion = try unboxer.unbox(key: "compatibilityVersion")
         self.developmentRegion = unboxer.unbox(key: "developmentRegion")

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -6,6 +6,9 @@ public class PBXProject: PBXObject, Hashable {
 
     // MARK: - Attributes
 
+    // xcodeproj's name
+    public var name: String
+
     // The object is a reference to a XCConfigurationList element.
     public var buildConfigurationList: String
 
@@ -47,6 +50,7 @@ public class PBXProject: PBXObject, Hashable {
     /// Initializes the project with its attributes
     ///
     /// - Parameters:
+    ///   - name: xcodeproj's name.
     ///   - reference: element reference.
     ///   - buildConfigurationList: project build configuration list.
     ///   - compatibilityVersion: project compatibility version.
@@ -60,7 +64,8 @@ public class PBXProject: PBXObject, Hashable {
     ///   - projectRoot: project root.
     ///   - targets: project targets.
     ///   - attributes: project attributes.
-    public init(reference: String,
+    public init(name: String,
+                reference: String,
                 buildConfigurationList: String,
                 compatibilityVersion: String,
                 mainGroup: String,
@@ -73,6 +78,7 @@ public class PBXProject: PBXObject, Hashable {
                 projectRoot: String? = nil,
                 targets: [String] = [],
                 attributes: [String: Any] = [:]) {
+        self.name = name
         self.buildConfigurationList = buildConfigurationList
         self.compatibilityVersion = compatibilityVersion
         self.mainGroup = mainGroup
@@ -96,6 +102,7 @@ public class PBXProject: PBXObject, Hashable {
     /// - Throws: throws an error in case any of the propeties are missing or they have the wrong type.
     public override init(reference: String, dictionary: [String: Any]) throws {
         let unboxer = Unboxer(dictionary: dictionary)
+        self.name = try unboxer.unbox(key: "name")
         self.buildConfigurationList = try unboxer.unbox(key: "buildConfigurationList")
         self.compatibilityVersion = try unboxer.unbox(key: "compatibilityVersion")
         self.developmentRegion = unboxer.unbox(key: "developmentRegion")
@@ -137,7 +144,7 @@ extension PBXProject: PlistSerializable {
     func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(PBXProject.isa))
-        let buildConfigurationListComment = "Build configuration list for PBXProject"
+        let buildConfigurationListComment = "Build configuration list for PBXProject \"\(name)\""
         let buildConfigurationListCommentedString = CommentedString(buildConfigurationList,
                                                                                 comment: buildConfigurationListComment)
         dictionary["buildConfigurationList"] = .string(buildConfigurationListCommentedString)

--- a/Sources/xcproj/XCConfigurationList.swift
+++ b/Sources/xcproj/XCConfigurationList.swift
@@ -71,8 +71,8 @@ extension XCConfigurationList: PlistSerializable {
     private func plistComment(proj: PBXProj) -> String? {
         let project = proj.projects.filter { $0.buildConfigurationList == self.reference }.first
         let target = proj.nativeTargets.filter { $0.buildConfigurationList == self.reference }.first
-        if project != nil {
-            return "Build configuration list for PBXProject"
+        if let project = project {
+            return "Build configuration list for PBXProject \"\(project.name)\""
         } else if let target = target {
             return "Build configuration list for PBXNativeTarget \"\(target.name)\""
         }

--- a/Tests/xcprojTests/PBXProjectSpec.swift
+++ b/Tests/xcprojTests/PBXProjectSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import xcproj
+@testable import xcproj
 
 final class PBXProjectSpec: XCTestCase {
 
@@ -41,6 +41,16 @@ final class PBXProjectSpec: XCTestCase {
         XCTAssertEqual(subject.projectReferences as! [String], ["ref"])
         XCTAssertEqual(subject.projectRoot, "root")
         XCTAssertEqual(subject.targets, ["target"])
+    }
+
+    func test_plistKeyAndValue() {
+        let proj = PBXProj(archiveVersion: 1, objectVersion: 1, rootObject: "")
+        let (_, plistValue) = subject.plistKeyAndValue(proj: proj)
+        guard let v = plistValue.dictionary?["buildConfigurationList"]?.string else {
+            XCTFail()
+            return
+        }
+        XCTAssertEqual(v, CommentedString("config", comment: "Build configuration list for PBXProject \"App\""))
     }
 
     func test_init_failsIfBuildConfigurationListIsMissing() {

--- a/Tests/xcprojTests/PBXProjectSpec.swift
+++ b/Tests/xcprojTests/PBXProjectSpec.swift
@@ -8,7 +8,8 @@ final class PBXProjectSpec: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        subject = PBXProject(reference: "uuid",
+        subject = PBXProject(name: "App",
+                             reference: "uuid",
                              buildConfigurationList: "config",
                              compatibilityVersion: "version",
                              mainGroup: "main",
@@ -27,6 +28,7 @@ final class PBXProjectSpec: XCTestCase {
     }
 
     func test_init_initializesTheProjectWithTheRightAttributes() {
+        XCTAssertEqual(subject.name, "App")
         XCTAssertEqual(subject.reference, "uuid")
         XCTAssertEqual(subject.buildConfigurationList, "config")
         XCTAssertEqual(subject.compatibilityVersion, "version")
@@ -69,7 +71,8 @@ final class PBXProjectSpec: XCTestCase {
     }
 
     func test_equal_returnsTheCorrectValue() {
-        let another = PBXProject(reference: "uuid",
+        let another = PBXProject(name: "App",
+                                 reference: "uuid",
                                  buildConfigurationList: "config",
                                  compatibilityVersion: "version",
                                  mainGroup: "main",

--- a/Tests/xcprojTests/XCConfigurationListSpec.swift
+++ b/Tests/xcprojTests/XCConfigurationListSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import xcproj
+@testable import xcproj
 
 final class XCConfigurationListSpec: XCTestCase {
 
@@ -17,4 +17,10 @@ final class XCConfigurationListSpec: XCTestCase {
         XCTAssertEqual(XCConfigurationList.isa, "XCConfigurationList")
     }
 
+    func test_plistKeyAndValue() {
+        let proj = PBXProj(archiveVersion: 1, objectVersion: 1, rootObject: "")
+        proj.projects = [PBXProject.init(name: "App", reference: "", buildConfigurationList: "reference", compatibilityVersion: "47", mainGroup: "")]
+        let (commentedString, _) = subject.plistKeyAndValue(proj: proj)
+        XCTAssertEqual(commentedString, CommentedString("reference", comment: "Build configuration list for PBXProject \"App\""))
+    }
 }


### PR DESCRIPTION
Related: https://github.com/xcodeswift/xcproj/issues/60

Fixes wrong comment on buildConfigurationList

```diff
-                       buildConfigurationList = XCCL47994501 /* Build configuration list for PBXProject */;
+                       buildConfigurationList = XCCL47994501 /* Build configuration list for PBXProject "LGTM" */;
```
```diff
-               XCCL47994501 /* Build configuration list for PBXProject */ = {
+               XCCL47994501 /* Build configuration list for PBXProject "LGTM" */ = {
                        isa = XCConfigurationList;
                        buildConfigurations = (
                                XCBC47994501 /* Debug */,
```