### PR TITLE
Fix classes type: array => dictionary

### DIFF
--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -14,7 +14,7 @@ public class PBXProj {
     public var objectVersion: Int
 
     /// Project classes.
-    public var classes: [Any]
+    public var classes: [String: Any]
 
     /// Project root object.
     public var rootObject: String
@@ -51,7 +51,7 @@ public class PBXProj {
     public init(archiveVersion: Int,
                 objectVersion: Int,
                 rootObject: String,
-                classes: [Any] = [],
+                classes: [String: Any] = [:],
                 objects: [PBXObject] = []) {
         self.archiveVersion = archiveVersion
         self.objectVersion = objectVersion
@@ -154,7 +154,7 @@ public class PBXProj {
         let unboxer = Unboxer(dictionary: dictionary)
         self.archiveVersion = try unboxer.unbox(key: "archiveVersion")
         self.objectVersion = try unboxer.unbox(key: "objectVersion")
-        self.classes = (dictionary["classes"] as? [Any]) ?? []
+        self.classes = (dictionary["classes"] as? [String: Any]) ?? [:]
         let objectsDictionary: [String: [String: Any]] = try unboxer.unbox(key: "objects")
         self.rootObject = try unboxer.unbox(key: "rootObject")
         objects = try objectsDictionary.flatMap { try PBXObject.parse(reference: $0.key, dictionary: $0.value) }
@@ -178,7 +178,7 @@ extension PBXProj: Equatable {
     public static func == (lhs: PBXProj, rhs: PBXProj) -> Bool {
         return lhs.archiveVersion == rhs.archiveVersion &&
             lhs.objectVersion == rhs.objectVersion &&
-            NSArray(array: lhs.classes).isEqual(to: NSArray(array: rhs.classes)) &&
+            NSDictionary(dictionary: lhs.classes).isEqual(to: NSDictionary(dictionary: rhs.classes)) &&
             lhs.buildFiles == rhs.buildFiles &&
             lhs.aggregateTargets == rhs.aggregateTargets &&
             lhs.containerItemProxies == rhs.containerItemProxies &&

--- a/Tests/xcprojTests/PBXProjSpec.swift
+++ b/Tests/xcprojTests/PBXProjSpec.swift
@@ -8,7 +8,7 @@ extension PBXProj {
     static func testData(archiveVersion: Int = 0,
                 objectVersion: Int = 1,
                 rootObject: String = "rootObject",
-                classes: [Any] = [],
+                classes: [String: Any] = [:],
                 objects: [PBXObject] = []) -> PBXProj {
         return PBXProj(archiveVersion: archiveVersion,
                        objectVersion: objectVersion,
@@ -30,7 +30,7 @@ final class PBXProjSpec: XCTestCase {
         subject = PBXProj(archiveVersion: 1,
                           objectVersion: 46,
                           rootObject: "root",
-                          classes: [],
+                          classes: [:],
                           objects: [object])
     }
 


### PR DESCRIPTION
Fixed wrong type of field `classes`.
It turns out that `classes` is dictionary, not array.

```diff
 // !$*UTF8*$!
 {
        archiveVersion = 1;
-       classes = (
-       );
+       classes = {
+       };
```