### PR TITLE
Fix wrong comment for copyFiles BuildPhase

### DIFF
--- a/Sources/xcproj/BuildPhase.swift
+++ b/Sources/xcproj/BuildPhase.swift
@@ -12,7 +12,7 @@ public enum BuildPhase: String {
     case sources = "Sources"
     case frameworks = "Frameworks"
     case resources = "Resources"
-    case copyFiles = "Copy Files"
+    case copyFiles = "CopyFiles"
     case runScript = "Run Script"
     case headers = "Headers"
 }

--- a/Tests/xcprojTests/BuildPhaseSpecs.swift
+++ b/Tests/xcprojTests/BuildPhaseSpecs.swift
@@ -17,7 +17,7 @@ class BuildPhaseSpecs: XCTestCase {
     }
 
     func test_copyFiles_hasTheCorrectRawValue() {
-        XCTAssertEqual(BuildPhase.copyFiles.rawValue, "Copy Files")
+        XCTAssertEqual(BuildPhase.copyFiles.rawValue, "CopyFiles")
     }
 
     func test_runStript_hasTheCorrectRawValue() {


### PR DESCRIPTION
```diff
                        files = (
-                               BF6866899801 /* LGTMKit_macOS.framework in Copy Files */,
-                               BF4806666702 /* APIKit.framework in Copy Files */,
-                               BF1804768702 /* Alamofire.framework in Copy Files */,
+                               BF6866899801 /* LGTMKit_macOS.framework in CopyFiles */,
+                               BF4806666702 /* APIKit.framework in CopyFiles */,
+                               BF1804768702 /* Alamofire.framework in CopyFiles */,
```