### PR TITLE
Support parsing XCVersionGroup objects from PBXObject

### DIFF
--- a/Sources/xcproj/PBXObject.swift
+++ b/Sources/xcproj/PBXObject.swift
@@ -67,6 +67,8 @@ public class PBXObject: Referenceable {
             return try PBXContainerItemProxy(reference: reference, dictionary: dictionary)
         case PBXReferenceProxy.isa:
             return try PBXReferenceProxy(reference: reference, dictionary: dictionary)
+        case XCVersionGroup.isa:
+            return try XCVersionGroup(reference: reference, dictionary: dictionary)
         default:
             throw PBXObjectError.unknownElement(isa)
         }


### PR DESCRIPTION
### Short description 📝
Although the element `XCVersionGroup` was defined it didn't get parsed.

### Solution 📦
Add `XCVersionGroup` element parsing.

### GIF
![gif](https://media.giphy.com/media/rF2Cplr6KCDG8/giphy.gif)
