### PR TITLE
 XCConfig: Improve regex matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,13 @@ You can check out the documentation on the following [link](https://xcodeswift.g
 
 ## Contributors ❤️
 
-[<img alt="Shakarang" src="https://avatars1.githubusercontent.com/u/8086925?v=4&s=117" width="117">](https://github.com/Shakarang)[<img alt="Mazyod" src="https://avatars3.githubusercontent.com/u/860511?v=4&s=117" width="117">](https://github.com/Mazyod)[<img alt="kixswift" src="https://avatars0.githubusercontent.com/u/10491362?v=4&s=117" width="117">](https://github.com/kixswift)[<img alt="artemnovichkov" src="https://avatars3.githubusercontent.com/u/5051597?v=4&s=117" width="117">](https://github.com/artemnovichkov)[<img alt="yonaskolb" src="https://avatars2.githubusercontent.com/u/2393781?v=4&s=117" width="117">](https://github.com/yonaskolb)
+[<img alt="Shakarang" src="https://avatars1.githubusercontent.com/u/8086925?v=4&s=117" width="117">](https://github.com/Shakarang)
+[<img alt="Mazyod" src="https://avatars3.githubusercontent.com/u/860511?v=4&s=117" width="117">](https://github.com/Mazyod)
+[<img alt="kixswift" src="https://avatars0.githubusercontent.com/u/10491362?v=4&s=117" width="117">](https://github.com/kixswift)
+[<img alt="artemnovichkov" src="https://avatars3.githubusercontent.com/u/5051597?v=4&s=117" width="117">](https://github.com/artemnovichkov)
+[<img alt="yonaskolb" src="https://avatars2.githubusercontent.com/u/2393781?v=4&s=117" width="117">](https://github.com/yonaskolb)
 [<img alt="pepibumur" src="https://avatars3.githubusercontent.com/u/663605?v=4&s=117" width="117">](https://github.com/pepibumur)
+[<img alt="toshi0383" src="https://avatars2.githubusercontent.com/u/6007952?v=4&s=117" width="117">](https://github.com/toshi0383)
 
 ## License
 

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -92,7 +92,9 @@ final class XCConfigParser {
             .first
     }
 
+    // swiftlint:disable:next force_try
     private static var includeRegex = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
+    // swiftlint:disable:next force_try
     private static var settingRegex = try! NSRegularExpression(pattern: "^([a-zA-Z0-9_\\[\\]=\\*~]+)\\s*=\\s*(\"?.*\"?)", options: [])
 }
 

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -93,7 +93,7 @@ final class XCConfigParser {
     }
 
     private static var includeRegex = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
-    private static var settingRegex = try! NSRegularExpression(pattern: "([^\\s=]+)\\s*=\\s*(\"?.*\"?)", options: [])
+    private static var settingRegex = try! NSRegularExpression(pattern: "^([a-zA-Z0-9_\\[\\]=\\*~]+)\\s*=\\s*(\"?.*\"?)", options: [])
 }
 
 // MARK: - XCConfig Extension (Equatable)

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -92,9 +92,7 @@ final class XCConfigParser {
             .first
     }
 
-    // swiftlint:disable:next force_try line_length
     private static var includeRegex = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
-    // swiftlint:disable:next force_try line_length
     private static var settingRegex = try! NSRegularExpression(pattern: "([^\\s=]+)\\s*=\\s*(\"?.*\"?)", options: [])
 }
 

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -73,7 +73,7 @@ public class XCConfig {
         }
     }
 
-    private static func settingFrom(line: String) -> (key: String, value: String)? {
+    static func settingFrom(line: String) -> (key: String, value: String)? {
         return XCConfig.settingRegex.matches(in: line,
                                              options: NSRegularExpression.MatchingOptions(rawValue: 0),
                                              range: NSRange(location: 0,
@@ -92,7 +92,7 @@ public class XCConfig {
     // swiftlint:disable:next force_try line_length
     private static var includeRegex: NSRegularExpression = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
     // swiftlint:disable:next force_try line_length
-    private static var settingRegex: NSRegularExpression = try! NSRegularExpression(pattern: "(.+)\\s+=\\s+(\"?.[^\"]+\"?)", options: .caseInsensitive)
+    private static var settingRegex: NSRegularExpression = try! NSRegularExpression(pattern: "([^\\s]+)\\s*=\\s*(\"?[^\"]+\"?)", options: [])
 
 }
 

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -34,22 +34,25 @@ public class XCConfig {
         if !path.exists { throw XCConfigError.notFound(path: path) }
         let fileLines = try path.read().components(separatedBy: "\n")
         self.includes = fileLines
-            .flatMap(XCConfig.configFrom(path: path))
+            .flatMap(XCConfigParser.configFrom(path: path))
         var buildSettings: [String: String] = [:]
         fileLines
-            .flatMap(XCConfig.settingFrom)
+            .flatMap(XCConfigParser.settingFrom)
             .forEach { buildSettings[$0.key] = $0.value }
         self.buildSettings = buildSettings
     }
+}
+
+final class XCConfigParser {
 
     /// Given the path the line is being parsed from, it returns a function that parses a line,
     /// and returns the include path and the config that the include is pointing to.
     ///
     /// - Parameter path: path of the config file that the line belongs to.
     /// - Returns: function that parses the line.
-    private static func configFrom(path: Path) -> (String) -> (include: Path, config: XCConfig)? {
+    static func configFrom(path: Path) -> (String) -> (include: Path, config: XCConfig)? {
         return { line in
-            return XCConfig.includeRegex.matches(in: line,
+            return includeRegex.matches(in: line,
                                                  options: NSRegularExpression.MatchingOptions(rawValue: 0),
                                                  range: NSRange(location: 0,
                                                                 length: line.characters.count))
@@ -74,7 +77,7 @@ public class XCConfig {
     }
 
     static func settingFrom(line: String) -> (key: String, value: String)? {
-        return XCConfig.settingRegex.matches(in: line,
+        return settingRegex.matches(in: line,
                                              options: NSRegularExpression.MatchingOptions(rawValue: 0),
                                              range: NSRange(location: 0,
                                                             length: line.characters.count))
@@ -93,7 +96,6 @@ public class XCConfig {
     private static var includeRegex: NSRegularExpression = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
     // swiftlint:disable:next force_try line_length
     private static var settingRegex: NSRegularExpression = try! NSRegularExpression(pattern: "([^\\s]+)\\s*=\\s*(\"?[^\"]+\"?)", options: [])
-
 }
 
 // MARK: - XCConfig Extension (Equatable)

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -93,9 +93,9 @@ final class XCConfigParser {
     }
 
     // swiftlint:disable:next force_try line_length
-    private static var includeRegex: NSRegularExpression = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
+    private static var includeRegex = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
     // swiftlint:disable:next force_try line_length
-    private static var settingRegex: NSRegularExpression = try! NSRegularExpression(pattern: "([^\\s]+)\\s*=\\s*(\"?[^\"]+\"?)", options: [])
+    private static var settingRegex = try! NSRegularExpression(pattern: "([^\\s=]+)\\s*=\\s*(\"?.*\"?)", options: [])
 }
 
 // MARK: - XCConfig Extension (Equatable)

--- a/Tests/xcprojTests/XCConfigSpec.swift
+++ b/Tests/xcprojTests/XCConfigSpec.swift
@@ -32,13 +32,13 @@ final class XCConfigSpec: XCTestCase {
     func test_xcconfig_settingRegex() {
         do {
             let line = "A = a"
-            let (key, value) = XCConfig.settingFrom(line: line)!
+            let (key, value) = XCConfigParser.settingFrom(line: line)!
             XCTAssertEqual("A", key)
             XCTAssertEqual("a", value)
         }
         do {
             let line = "B=b"
-            let (key, value) = XCConfig.settingFrom(line: line)!
+            let (key, value) = XCConfigParser.settingFrom(line: line)!
             XCTAssertEqual("B", key)
             XCTAssertEqual("b", value)
         }

--- a/Tests/xcprojTests/XCConfigSpec.swift
+++ b/Tests/xcprojTests/XCConfigSpec.swift
@@ -54,6 +54,16 @@ final class XCConfigSpec: XCTestCase {
             XCTAssertEqual("B", key)
             XCTAssertEqual("\"b\\\"b\"", value)
         }
+        do {
+            let line = "// A = a"
+            XCTAssertNil(XCConfigParser.settingFrom(line: line))
+        }
+        do {
+            let line = "A[sdk=iphoneos*] = a"
+            let (key, value) = XCConfigParser.settingFrom(line: line)!
+            XCTAssertEqual("A[sdk=iphoneos*]", key)
+            XCTAssertEqual("a", value)
+        }
     }
 
     func test_errorDescription_returnsTheCorrectDescription_whenNotFound() {

--- a/Tests/xcprojTests/XCConfigSpec.swift
+++ b/Tests/xcprojTests/XCConfigSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import xcproj
+@testable import xcproj
 import PathKit
 
 final class XCConfigSpec: XCTestCase {
@@ -27,6 +27,21 @@ final class XCConfigSpec: XCTestCase {
         let buildSettings = config.flattenedBuildSettings()
         XCTAssertEqual(buildSettings["a"] as? String, "2")
         XCTAssertEqual(buildSettings["b"] as? String, "3")
+    }
+
+    func test_xcconfig_settingRegex() {
+        do {
+            let line = "A = a"
+            let (key, value) = XCConfig.settingFrom(line: line)!
+            XCTAssertEqual("A", key)
+            XCTAssertEqual("a", value)
+        }
+        do {
+            let line = "B=b"
+            let (key, value) = XCConfig.settingFrom(line: line)!
+            XCTAssertEqual("B", key)
+            XCTAssertEqual("b", value)
+        }
     }
 
     func test_errorDescription_returnsTheCorrectDescription_whenNotFound() {

--- a/Tests/xcprojTests/XCConfigSpec.swift
+++ b/Tests/xcprojTests/XCConfigSpec.swift
@@ -42,6 +42,18 @@ final class XCConfigSpec: XCTestCase {
             XCTAssertEqual("B", key)
             XCTAssertEqual("b", value)
         }
+        do {
+            let line = "B=\"b=b=b=\""
+            let (key, value) = XCConfigParser.settingFrom(line: line)!
+            XCTAssertEqual("B", key)
+            XCTAssertEqual("\"b=b=b=\"", value)
+        }
+        do {
+            let line = "B=\"b\\\"b\""
+            let (key, value) = XCConfigParser.settingFrom(line: line)!
+            XCTAssertEqual("B", key)
+            XCTAssertEqual("\"b\\\"b\"", value)
+        }
     }
 
     func test_errorDescription_returnsTheCorrectDescription_whenNotFound() {


### PR DESCRIPTION
XCConfig now loads buildSettings like these correctly.
```
// non-whitespace around =
PRODUCT_BUNDLE_IDENTIFIER=jp.toshi0383.mac.LGTM
// One character key or value
A=a
// sdk brackets
A[sdk=iphoneos*] = a
// comment is ignored
// A = a
```