### PR TITLE
write collect classes type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
 language: generic
 osx_image: xcode9
 install:
-  - brew install swiftlint
+  - brew upgrade swiftlint
   - bundle install
 script:
   - bundle exec rake ci

--- a/Sources/xcproj/PBXProjWriter.swift
+++ b/Sources/xcproj/PBXProjWriter.swift
@@ -22,7 +22,7 @@ class PBXProjWriter {
         writeNewLine()
         writeDictionaryStart()
         write(dictionaryKey: "archiveVersion", dictionaryValue: .string(CommentedString("\(proj.archiveVersion)")))
-        write(dictionaryKey: "classes", dictionaryValue: .array([]))
+        write(dictionaryKey: "classes", dictionaryValue: .dictionary([:]))
         write(dictionaryKey: "objectVersion", dictionaryValue: .string(CommentedString("\(proj.objectVersion)")))
         writeIndent()
         write(string: "objects = {")

--- a/Tests/xcprojTests/PBXProjWriterSpec.swift
+++ b/Tests/xcprojTests/PBXProjWriterSpec.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import xcproj
 
-class PBXProjWriterSpecs: XCTestCase {
+class PBXProjWriterSpec: XCTestCase {
 
     func test_dictionaryPlistValue_returnsTheCorrectValue() {
         let dictionary: [String: Any] = [


### PR DESCRIPTION
PBXProjWriter was still writing in array.

Related: https://github.com/xcodeswift/xcproj/pull/94

Also renamed spec file for consistency.