### PR TITLE
Prevent errors parsing misformated project using default values

### DIFF
--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -37,10 +37,9 @@ public class PBXBuildFile: PBXObject, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let reference: String = try container.decode(.reference)
-        self.fileRef = try container.decode(.fileRef)        
+        self.fileRef = try container.decodeIfPresent(.fileRef) ?? ""
         self.settings = try container.decodeIfPresent([String: Any].self, forKey: .settings) ?? [:]
-        super.init(reference: reference)
+        try super.init(from: decoder)
     }
     
     // MARK: - Hashable

--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -33,13 +33,12 @@ public class PBXBuildPhase: PBXObject {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let buildActionMaskString: String = try container.decode(.buildActionMask)
+        let buildActionMaskString: String = try container.decodeIfPresent(.buildActionMask) ?? ""
         self.buildActionMask = UInt(buildActionMaskString) ?? 0
-        self.files = try container.decode(.files)
-        let runOnlyForDeploymentPostprocessingString: String = try container.decode(.runOnlyForDeploymentPostprocessing)
+        self.files = try container.decodeIfPresent(.files) ?? []
+        let runOnlyForDeploymentPostprocessingString: String = try container.decodeIfPresent(.runOnlyForDeploymentPostprocessing) ?? ""
         self.runOnlyForDeploymentPostprocessing = UInt(runOnlyForDeploymentPostprocessingString) ?? 0
-        let reference: String = try container.decode(.reference)
-        super.init(reference: reference)
+        try super.init(from: decoder)
     }
 
     public static func == (lhs: PBXBuildPhase,

--- a/Sources/xcproj/PBXContainerItemProxy.swift
+++ b/Sources/xcproj/PBXContainerItemProxy.swift
@@ -60,10 +60,10 @@ public class PBXContainerItemProxy: PBXObject, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.containerPortal = try container.decode(.containerPortal)
-        let proxyTypeString: String = try container.decode(.proxyType)
+        self.containerPortal = try container.decodeIfPresent(.containerPortal) ?? ""
+        let proxyTypeString: String = try container.decodeIfPresent(.proxyType) ?? ""
         self.proxyType = UInt(proxyTypeString).flatMap({ProxyType(rawValue: $0)}) ?? .other
-        self.remoteGlobalIDString = try container.decode(.remoteGlobalIDString)
+        self.remoteGlobalIDString = try container.decodeIfPresent(.remoteGlobalIDString) ?? ""
         self.remoteInfo = try container.decodeIfPresent(.remoteInfo)
         try super.init(from: decoder)
     }

--- a/Sources/xcproj/PBXCopyFilesBuildPhase.swift
+++ b/Sources/xcproj/PBXCopyFilesBuildPhase.swift
@@ -77,8 +77,8 @@ public class PBXCopyFilesBuildPhase: PBXBuildPhase, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.dstPath = try container.decode(.dstPath)
-        let dstSubfolderSpecString: String = try container.decode(.dstSubfolderSpec)
+        self.dstPath = try container.decodeIfPresent(.dstPath) ?? ""
+        let dstSubfolderSpecString: String = try container.decodeIfPresent(.dstSubfolderSpec) ?? ""
         self.dstSubfolderSpec = UInt(dstSubfolderSpecString).flatMap(SubFolder.init) ?? .other
         self.name = try container.decodeIfPresent(.name)
         try super.init(from: decoder)

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -51,11 +51,10 @@ public class PBXFileElement: PBXObject, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.sourceTree = try container.decode(.sourceTree)
-        self.name = try container.decode(.name)
-        self.path = try container.decode(.path)
-        let reference: String = try container.decode(.reference)
-        super.init(reference: reference)
+        self.sourceTree = try container.decodeIfPresent(.sourceTree) ?? .none
+        self.name = try container.decodeIfPresent(.name) ?? ""
+        self.path = try container.decodeIfPresent(.path) ?? ""
+        try super.init(from: decoder)
     }
     
 }

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -102,7 +102,7 @@ public class PBXFileReference: PBXObject, Hashable {
         self.includeInIndex = includeInIndexString.flatMap({Int($0)})
         self.name = try container.decodeIfPresent(.name)
         self.path = try container.decodeIfPresent(.path)
-        self.sourceTree = try container.decode(.sourceTree)
+        self.sourceTree = try container.decodeIfPresent(.sourceTree) ?? .none
         self.usesTabs = try container.decodeIfPresent(.usesTabs)
         self.lineEnding = try container.decodeIfPresent(.lineEnding)
         self.xcLanguageSpecificationIdentifier = try container.decodeIfPresent(.xcLanguageSpecificationIdentifier)

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -61,7 +61,7 @@ public class PBXGroup: PBXObject, Hashable {
         self.name = try container.decodeIfPresent(.name)
         self.children = (try container.decodeIfPresent(.children)) ?? []
         self.path = try container.decodeIfPresent(.path)
-        self.sourceTree = try container.decode(.sourceTree)
+        self.sourceTree = try container.decodeIfPresent(.sourceTree) ?? .none
         try super.init(from: decoder)
     }
     

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -146,11 +146,11 @@ public class PBXProj: Decodable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let archiveVersionString: String = try container.decode(.archiveVersion)
+        let archiveVersionString: String = try container.decodeIfPresent(.archiveVersion) ?? ""
         self.archiveVersion = Int(archiveVersionString) ?? 0
-        let objectVersionString: String = try container.decode(.objectVersion)
+        let objectVersionString: String = try container.decodeIfPresent(.objectVersion) ?? ""
         self.objectVersion = Int(objectVersionString) ?? 0
-        self.rootObject = try container.decode(.rootObject)
+        self.rootObject = try container.decodeIfPresent(.rootObject) ?? ""
         self.classes = try container.decodeIfPresent([String: Any].self, forKey: .classes) ?? [:]        
         let objectsDictionary: [String: Any] = try container.decodeIfPresent([String: Any].self, forKey: .objects) ?? [:]
         let objects: [String: [String: Any]] = (objectsDictionary as? [String: [String: Any]]) ?? [:]

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -114,17 +114,17 @@ public class PBXProject: PBXObject, Hashable {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = (try container.decodeIfPresent(.name)) ?? ""
-        self.buildConfigurationList = try container.decode(.buildConfigurationList)
-        self.compatibilityVersion = try container.decode(.compatibilityVersion)
+        self.buildConfigurationList = try container.decodeIfPresent(.buildConfigurationList) ?? ""
+        self.compatibilityVersion = try container.decodeIfPresent(.compatibilityVersion) ?? ""
         self.developmentRegion = try container.decodeIfPresent(.developmentRegion)
         let hasScannedForEncodingsString: String? = try container.decodeIfPresent(.hasScannedForEncodings)
         self.hasScannedForEncodings = hasScannedForEncodingsString.flatMap({Int($0)})
         self.knownRegions = (try container.decodeIfPresent(.knownRegions)) ?? []
-        self.mainGroup = try container.decode(.mainGroup)
+        self.mainGroup = try container.decodeIfPresent(.mainGroup) ?? ""
         self.productRefGroup = try container.decodeIfPresent(.productRefGroup)
         self.projectDirPath = try container.decodeIfPresent(.projectDirPath)
         self.projectReferences = (try container.decodeIfPresent(.projectReferences)) ?? []
-        self.projectRoot = try container.decode(.projectRoot)
+        self.projectRoot = try container.decodeIfPresent(.projectRoot)
         self.targets = (try container.decodeIfPresent(.targets)) ?? []
         self.attributes = try container.decodeIfPresent([String: Any].self, forKey: .attributes) ?? [:]
         try super.init(from: decoder)

--- a/Sources/xcproj/PBXReferenceProxy.swift
+++ b/Sources/xcproj/PBXReferenceProxy.swift
@@ -44,10 +44,10 @@ public class PBXReferenceProxy: PBXObject, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.fileType = try container.decode(.fileType)
-        self.path = try container.decode(.path)
-        self.remoteRef = try container.decode(.remoteRef)
-        self.sourceTree = try container.decode(.sourceTree)
+        self.fileType = try container.decodeIfPresent(.fileType) ?? ""
+        self.path = try container.decodeIfPresent(.path) ?? ""
+        self.remoteRef = try container.decodeIfPresent(.remoteRef) ?? ""
+        self.sourceTree = try container.decodeIfPresent(.sourceTree) ?? .none
         try super.init(from: decoder)
     }
     

--- a/Sources/xcproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcproj/PBXShellScriptBuildPhase.swift
@@ -71,10 +71,10 @@ public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.name = try container.decode(.name)
+        self.name = try container.decodeIfPresent(.name) ?? ""
         self.inputPaths = (try container.decodeIfPresent(.inputPaths)) ?? []
         self.outputPaths = (try container.decodeIfPresent(.outputPaths)) ?? []
-        self.shellPath = try container.decode(.shellPath)
+        self.shellPath = try container.decodeIfPresent(.shellPath) ?? ""
         self.shellScript = try container.decodeIfPresent(.shellScript)
         self.showEnvVarsInLog = try container.decodeIfPresent(.showEnvVarsInLog)
         try super.init(from: decoder)

--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -63,16 +63,15 @@ public class PBXTarget: PBXObject, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.buildConfigurationList = try container.decode(.buildConfigurationList)
-        self.buildPhases = try container.decode(.buildPhases)
-        self.buildRules = try container.decode(.buildRules)
-        self.dependencies = try container.decode(.dependencies)
-        self.name = try container.decode(.name)
+        self.buildConfigurationList = try container.decodeIfPresent(.buildConfigurationList) ?? ""
+        self.buildPhases = try container.decodeIfPresent(.buildPhases) ?? []
+        self.buildRules = try container.decodeIfPresent(.buildRules) ?? []
+        self.dependencies = try container.decodeIfPresent(.dependencies) ?? []
+        self.name = try container.decodeIfPresent(.name) ?? ""
         self.productName = try container.decodeIfPresent(.productName)
         self.productReference = try container.decodeIfPresent(.productReference)
         self.productType = try container.decodeIfPresent(.productType)
-        let reference: String = try container.decode(.reference)
-        super.init(reference: reference)
+        try super.init(from: decoder)
     }
 
     public static func == (lhs: PBXTarget,

--- a/Sources/xcproj/PBXTargetDependency.swift
+++ b/Sources/xcproj/PBXTargetDependency.swift
@@ -45,8 +45,8 @@ public class PBXTargetDependency: PBXObject, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.target = try container.decode(.target)
-        self.targetProxy = try container.decode(.targetProxy)
+        self.target = try container.decodeIfPresent(.target) ?? ""
+        self.targetProxy = try container.decodeIfPresent(.targetProxy) ?? ""
         try super.init(from: decoder)
     }
     

--- a/Sources/xcproj/PBXVariantGroup.swift
+++ b/Sources/xcproj/PBXVariantGroup.swift
@@ -44,11 +44,10 @@ public class PBXVariantGroup: PBXObject, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.children = try container.decode([String].self, forKey: .children)
-        self.name = try container.decode(String.self, forKey: .name)
-        self.sourceTree = try container.decode(PBXSourceTree.self, forKey: .sourceTree)
-        let reference = try container.decode(String.self, forKey: .reference)
-        super.init(reference: reference)
+        self.children = try container.decodeIfPresent(.children) ?? []
+        self.name = try container.decodeIfPresent(.name) ?? ""
+        self.sourceTree = try container.decodeIfPresent(.sourceTree) ?? .none
+        try super.init(from: decoder)
     }
     
     // MARK: - Hashable

--- a/Sources/xcproj/XCBuildConfiguration.swift
+++ b/Sources/xcproj/XCBuildConfiguration.swift
@@ -52,8 +52,8 @@ public class XCBuildConfiguration: PBXObject, Hashable {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.baseConfigurationReference = try container.decodeIfPresent(.baseConfigurationReference)
-        self.buildSettings = try container.decode([String: Any].self, forKey: .buildSettings)
-        self.name = try container.decode(.name)
+        self.buildSettings = try container.decodeIfPresent([String: Any].self, forKey: .buildSettings) ?? [:]
+        self.name = try container.decodeIfPresent(.name) ?? ""
         try super.init(from: decoder)
     }
     

--- a/Sources/xcproj/XCConfigurationList.swift
+++ b/Sources/xcproj/XCConfigurationList.swift
@@ -51,9 +51,9 @@ public class XCConfigurationList: PBXObject, Hashable {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.buildConfigurations = (try container.decodeIfPresent(.buildConfigurations)) ?? []
-        let defaultConfigurationIsVisibleString: String = try container.decode(.defaultConfigurationIsVisible)
+        let defaultConfigurationIsVisibleString: String = try container.decodeIfPresent(.defaultConfigurationIsVisible) ?? ""
         self.defaultConfigurationIsVisible = UInt(defaultConfigurationIsVisibleString) ?? 0
-        self.defaultConfigurationName = try container.decode(.defaultConfigurationName)
+        self.defaultConfigurationName = try container.decodeIfPresent(.defaultConfigurationName) ?? ""
         try super.init(from: decoder)
     }
     

--- a/Sources/xcproj/XCVersionGroup.swift
+++ b/Sources/xcproj/XCVersionGroup.swift
@@ -67,14 +67,13 @@ public class XCVersionGroup: PBXObject, Hashable {
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.currentVersion = try container.decode(String.self, forKey: .currentVersion)
-        self.path = try container.decode(String.self, forKey: .path)
+        self.currentVersion = try container.decodeIfPresent(.currentVersion) ?? ""
+        self.path = try container.decodeIfPresent(.path) ?? ""
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
-        self.sourceTree = try container.decode(PBXSourceTree.self, forKey: .sourceTree)
-        self.versionGroupType = try container.decode(String.self, forKey: .versionGroupType)
+        self.sourceTree = try container.decodeIfPresent(.sourceTree) ?? .none
+        self.versionGroupType = try container.decodeIfPresent(.versionGroupType) ?? ""
         self.children = try container.decodeIfPresent([String].self, forKey: .children) ?? []
-        let reference = try container.decode(String.self, forKey: .reference)
-        super.init(reference: reference)
+        try super.init(from: decoder)
     }
 }
 

--- a/Tests/xcprojTests/PBXAggregateTargetSpec.swift
+++ b/Tests/xcprojTests/PBXAggregateTargetSpec.swift
@@ -35,59 +35,49 @@ final class PBXAggregateTargetSpec: XCTestCase {
         XCTAssertEqual(subject.productType, .application)
     }
 
-    func test_init_failsWhenTheBuildConfigurationListIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenBuildConfigurationListIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "buildConfigurationList")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXAggregateTarget.self, from: data)
-            XCTAssertTrue(false, "It should throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXAggregateTarget.self, from: data)
+        XCTAssertEqual(subject.buildConfigurationList, "")
     }
-
-    func test_init_failsWhenBuildPhasesIsMissing() {
+    
+    func test_init_setsTheCorrectDefaultValue_whenBuildPhasesIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "buildPhases")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXAggregateTarget.self, from: data)
-            XCTAssertTrue(false, "It should throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXAggregateTarget.self, from: data)
+        XCTAssertTrue(subject.buildPhases.isEmpty)
     }
-
-    func test_init_failsWhenBuildRulesIsMissing() {
+    
+    func test_init_setsTheCorrectDefaultValue_whenBuildRulesMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "buildRules")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXAggregateTarget.self, from: data)
-            XCTAssertTrue(false, "It should throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXAggregateTarget.self, from: data)
+        XCTAssertTrue(subject.buildRules.isEmpty)
     }
 
-    func test_init_failsWhenDependenciesIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenDependenciesIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "dependencies")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXAggregateTarget.self, from: data)
-            XCTAssertTrue(false, "It should throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXAggregateTarget.self, from: data)
+        XCTAssertTrue(subject.dependencies.isEmpty)
     }
-
-    func test_init_failsWhenNameIsMissing() {
+    
+    func test_init_setsTheCorrectDefaultValue_whenNameIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "name")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXAggregateTarget.self, from: data)
-            XCTAssertTrue(false, "It should throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXAggregateTarget.self, from: data)
+        XCTAssertEqual(subject.name, "")
     }
 
     func test_equal_returnsTheCorrectValue() {

--- a/Tests/xcprojTests/PBXBuildFileSpec.swift
+++ b/Tests/xcprojTests/PBXBuildFileSpec.swift
@@ -19,15 +19,13 @@ final class PBXBuildFileSpec: XCTestCase {
         XCTAssertEqual(subject.settings as! [String: String], ["a": "b"])
     }
 
-    func test_initFails_ifFileRefIsMissing() {
+    func test_initFails_setsTheCorrectDefaultValue_whenFileRefIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "fileRef")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXBuildFile.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXBuildFile.self, from: data)
+        XCTAssertEqual(subject.fileRef, "")
     }
 
     func test_isa_returnsTheCorrectValue() {

--- a/Tests/xcprojTests/PBXContainerItemProxySpec.swift
+++ b/Tests/xcprojTests/PBXContainerItemProxySpec.swift
@@ -22,37 +22,31 @@ final class PBXContainerItemProxySpec: XCTestCase {
         XCTAssertEqual(subject.remoteInfo, "remote_info")
     }
 
-    func test_init_shouldFail_ifContainerPortalIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenContainerPortalIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "containerPortal")
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXContainerItemProxy.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXContainerItemProxy.self, from: data)
+        XCTAssertEqual(subject.containerPortal, "")
     }
-
-    func test_init_shouldFail_ifRemoteGlobalIDStringIsMissing() {
+    
+    func test_init_setsTheCorrectDefaultValue_whenRemoteGlobalIDStringIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "remoteGlobalIDString")
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXContainerItemProxy.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXContainerItemProxy.self, from: data)
+        XCTAssertEqual(subject.remoteGlobalIDString, "")
     }
-
-    func test_init_shouldFail_ifRemoteInfoIsMissing() {
+    
+    func test_init_setsTheCorrectDefaultValue_whenRemoteInfoIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "remoteInfo")
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXContainerItemProxy.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXContainerItemProxy.self, from: data)
+        XCTAssertNil(subject.remoteInfo)
     }
 
     func test_equal_shouldReturnTheCorrectValue() {

--- a/Tests/xcprojTests/PBXFileElementSpec.swift
+++ b/Tests/xcprojTests/PBXFileElementSpec.swift
@@ -33,15 +33,13 @@ final class PBXFileElementSpec: XCTestCase {
         XCTAssertEqual(subject, another)
     }
 
-    func test_init_failsIfSourceTreeIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenSourceTreeIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "sourceTree")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXFileElement.self, from: data)
-            XCTAssertTrue(false, "Expected to throw but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXFileElement.self, from: data)
+        XCTAssertEqual(subject.sourceTree, .none)
     }
 
     func test_init_failsIfPathIsMissing() {

--- a/Tests/xcprojTests/PBXFileReferenceSpec.swift
+++ b/Tests/xcprojTests/PBXFileReferenceSpec.swift
@@ -42,15 +42,13 @@ final class PBXFileReferenceSpec: XCTestCase {
         } catch {}
     }
 
-    func test_init_failsIfSourceTreeIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenSourceTreeIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "sourceTree")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXFileReference.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXFileReference.self, from: data)
+        XCTAssertEqual(subject.sourceTree, .none)
     }
 
     func test_equal_returnsTheCorrectValue() {

--- a/Tests/xcprojTests/PBXFrameworksBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXFrameworksBuildPhaseSpec.swift
@@ -34,15 +34,13 @@ final class PBXFrameworksBuildPhaseSpec: XCTestCase {
         } catch {}
     }
 
-    func test_init_fails_whenTheRunOnlyForDeploymentPostProcessingIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenRunOnlyForDeploymentPostprocessingIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "runOnlyForDeploymentPostprocessing")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXFrameworksBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXFrameworksBuildPhase.self, from: data)
+        XCTAssertEqual(subject.runOnlyForDeploymentPostprocessing, 0)
     }
 
     func test_equals_returnsTheCorrectValue() {

--- a/Tests/xcprojTests/PBXGroupSpec.swift
+++ b/Tests/xcprojTests/PBXGroupSpec.swift
@@ -21,26 +21,22 @@ final class PBXGroupSpec: XCTestCase {
         XCTAssertEqual(subject.name, "name")
     }
 
-    func test_init_failsIfChildrenIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenChildrenIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "children")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXGroup.self, from: data)
+        XCTAssertEqual(subject.children, [])
     }
 
-    func test_init_failsIfSourceTreeIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenSourceTreeIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "sourceTree")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXGroup.self, from: data)
+        XCTAssertEqual(subject.sourceTree, .none)
     }
 
     func test_isa_returnsTheCorrectValue() {
@@ -63,7 +59,7 @@ final class PBXGroupSpec: XCTestCase {
         return [
             "children": ["child"],
             "name": "name",
-            "sourceTree": "absolute",
+            "sourceTree": "<absolute>",
             "reference": "reference"
         ]
     }

--- a/Tests/xcprojTests/PBXNativeTargetSpec.swift
+++ b/Tests/xcprojTests/PBXNativeTargetSpec.swift
@@ -35,59 +35,49 @@ final class PBXNativeTargetSpec: XCTestCase {
         XCTAssertEqual(subject.productType, .application)
     }
 
-    func test_init_failsWhenBuildConfigurationListIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenBuildConfigurationListIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "buildConfigurationList")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXNativeTarget.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXNativeTarget.self, from: data)
+        XCTAssertEqual(subject.buildConfigurationList, "")
     }
 
-    func test_init_failsWhenBuildPhasesIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenBuildPhasesIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "buildPhases")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXNativeTarget.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXNativeTarget.self, from: data)
+        XCTAssertEqual(subject.buildPhases, [])
     }
 
-    func test_init_failsWhenBuildRulesIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenBuildRulesIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "buildRules")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXNativeTarget.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXNativeTarget.self, from: data)
+        XCTAssertEqual(subject.buildRules, [])
     }
 
-    func test_init_failsWhenDependenciesIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenDependenciesIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "dependencies")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXNativeTarget.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXNativeTarget.self, from: data)
+        XCTAssertEqual(subject.dependencies, [])
     }
 
-    func test_init_failsWhenNameIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenNameIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "name")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXNativeTarget.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXNativeTarget.self, from: data)
+        XCTAssertEqual(subject.name, "")
     }
 
     func test_equal_returnsTheCorrectValue() {

--- a/Tests/xcprojTests/PBXProjectSpec.swift
+++ b/Tests/xcprojTests/PBXProjectSpec.swift
@@ -53,37 +53,31 @@ final class PBXProjectSpec: XCTestCase {
         XCTAssertEqual(v, CommentedString("config", comment: "Build configuration list for PBXProject \"App\""))
     }
 
-    func test_init_failsIfBuildConfigurationListIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenBuildConfigurationListIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "buildConfigurationList")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXProject.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXProject.self, from: data)
+        XCTAssertEqual(subject.buildConfigurationList, "")
     }
-
-    func test_init_failsIfCompatibilityVersionIsMissing() {
+    
+    func test_init_setsTheCorrectDefaultValue_whenCompatibilityVersionIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "compatibilityVersion")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXProject.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXProject.self, from: data)
+        XCTAssertEqual(subject.compatibilityVersion, "")
     }
-
-    func test_init_failsIfMainGroupIsMissing() {
+    
+    func test_init_setsTheCorrectDefaultValue_whenMainGroupIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "mainGroup")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXProject.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXProject.self, from: data)
+        XCTAssertEqual(subject.mainGroup, "")
     }
 
     func test_equal_returnsTheCorrectValue() {

--- a/Tests/xcprojTests/PBXReferenceProxySpec.swift
+++ b/Tests/xcprojTests/PBXReferenceProxySpec.swift
@@ -23,48 +23,40 @@ final class PBXReferenceProxySpec: XCTestCase {
         XCTAssertEqual(subject.sourceTree, .absolute)
     }
 
-    func test_init_failsIfTheFileTypeIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenFileTypeIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "fileType")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXReferenceProxy.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXReferenceProxy.self, from: data)
+        XCTAssertEqual(subject.fileType, "")
     }
 
-    func test_init_failsIfThePathIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenPathIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "path")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXReferenceProxy.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXReferenceProxy.self, from: data)
+        XCTAssertEqual(subject.path, "")
     }
 
-    func test_init_failsIfTheRemoteRefIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenRemoteRefIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "remoteRef")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXReferenceProxy.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXReferenceProxy.self, from: data)
+        XCTAssertEqual(subject.remoteRef, "")
     }
 
-    func test_init_failsIfTheSourceTreeIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenSourceTreeIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "sourceTree")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXReferenceProxy.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXReferenceProxy.self, from: data)
+        XCTAssertEqual(subject.sourceTree, .none)
     }
 
     private func testDictionary() -> [String: Any] {

--- a/Tests/xcprojTests/PBXResourcesBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXResourcesBuildPhaseSpec.swift
@@ -19,15 +19,13 @@ final class PBXResourcesBuildPhaseSpec: XCTestCase {
         XCTAssertEqual(subject.runOnlyForDeploymentPostprocessing, 0)
     }
 
-    func test_initFails_whenRunOnlyForDeploymentPostprocessingIsMissing() {
+    func test_initSetsTheCorrectDefaultValue_whenRunOnlyForDeploymentPostprocessingIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "runOnlyForDeploymentPostprocessing")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXReferenceProxy.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXResourcesBuildPhase.self, from: data)
+        XCTAssertEqual(subject.runOnlyForDeploymentPostprocessing, 0)
     }
 
     func test_isa_returnsTheCorrectValue() {

--- a/Tests/xcprojTests/PBXShellScriptBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXShellScriptBuildPhaseSpec.swift
@@ -25,37 +25,31 @@ final class PBXShellScriptBuildPhaseSpec: XCTestCase {
         XCTAssertEqual(PBXShellScriptBuildPhase.isa, "PBXShellScriptBuildPhase")
     }
 
-    func test_initFails_whenTheFilesAreMissing() {
+    func test_initSetsTheCorrectDefaultValue_whenFilesIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "files")
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXShellScriptBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXShellScriptBuildPhase.self, from: data)
+        XCTAssertEqual(subject.files, [])
     }
-
-    func test_initFails_whenShellPathIsMissing() {
+    
+    func test_initSetsTheCorrectDefaultValue_whenShellPathIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "shellPath")
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXShellScriptBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXShellScriptBuildPhase.self, from: data)
+        XCTAssertEqual(subject.shellPath, "")
     }
 
-    func test_initFails_whenNameIsMissing() {
+    func test_initSetsTheCorrectDefaultValue_whenNameIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "name")
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXShellScriptBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXShellScriptBuildPhase.self, from: data)
+        XCTAssertEqual(subject.name, "")
     }
 
     func test_equals_returnsTheCorrectValue() {

--- a/Tests/xcprojTests/PBXSourcesBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXSourcesBuildPhaseSpec.swift
@@ -32,15 +32,13 @@ class PBXSourcesBuildPhaseSpec: XCTestCase {
         XCTAssertEqual(subject.hashValue, subject.reference.hashValue)
     }
 
-    func test_init_failsIfFilesAreMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenFilesIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "files")
         let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXResourcesBuildPhase.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXResourcesBuildPhase.self, from: data)
+        XCTAssertEqual(subject.files, [])
     }
 
 

--- a/Tests/xcprojTests/PBXTargetDependencySpec.swift
+++ b/Tests/xcprojTests/PBXTargetDependencySpec.swift
@@ -18,26 +18,22 @@ final class PBXTargetDependencySpec: XCTestCase {
         XCTAssertEqual(subject.targetProxy, "target_proxy")
     }
 
-    func test_init_failsIfTheTargetIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenTargetIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "target")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXTargetDependency.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXTargetDependency.self, from: data)
+        XCTAssertEqual(subject.target, "")
     }
 
-    func test_init_failsIfTheTargetProxyIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenTargetProxyIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "targetProxy")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXTargetDependency.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXTargetDependency.self, from: data)
+        XCTAssertEqual(subject.targetProxy, "")
     }
 
     func test_hasTheCorrectIsa() {

--- a/Tests/xcprojTests/PBXVariantGroupSpec.swift
+++ b/Tests/xcprojTests/PBXVariantGroupSpec.swift
@@ -21,37 +21,31 @@ final class PBXVariantGroupSpec: XCTestCase {
         XCTAssertEqual(subject.sourceTree, .group)
     }
 
-    func test_init_failsIfTheChildrenIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenChildrenIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "children")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXVariantGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXVariantGroup.self, from: data)
+        XCTAssertEqual(subject.children, [])
     }
 
-    func test_init_failsIfTheNameIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenNameIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "name")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXVariantGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXVariantGroup.self, from: data)
+        XCTAssertEqual(subject.name, "")
     }
 
-    func test_init_failsIfTheSourceTreeIsMissing() {
+    func test_init_setsTheCorrectDefaultValue_whenSourceTreeIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "sourceTree")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXVariantGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(PBXVariantGroup.self, from: data)
+        XCTAssertEqual(subject.sourceTree, .none)
     }
 
     func test_init_failsIfTheSourceTreeIsWrong() {

--- a/Tests/xcprojTests/XCBuildConfigurationSpec.swift
+++ b/Tests/xcprojTests/XCBuildConfigurationSpec.swift
@@ -23,15 +23,13 @@ final class XCBuildConfigurationSpec: XCTestCase {
         XCTAssertEqual(subject.buildSettings as! [String: String], [:])
     }
 
-    func test_initFails_ifNameIsMissing() {
+    func test_setsTheCorrectDefaultValue_whenNameIsMissing() throws {
         var dictionary = testDictionary()
         dictionary.removeValue(forKey: "name")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(XCBuildConfiguration.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
+        let subject = try decoder.decode(XCBuildConfiguration.self, from: data)
+        XCTAssertEqual(subject.name, "")
     }
 
     func test_isa_hasTheCorrectValue() {

--- a/Tests/xcprojTests/XCVersionGroupSpec.swift
+++ b/Tests/xcprojTests/XCVersionGroupSpec.swift
@@ -46,48 +46,40 @@ final class XCVersionGroupSpec: XCTestCase {
         XCTAssertNotEqual(a, b)
     }
 
-    func test_initFails_whenCurrentVersionIsMissing() {
+    func test_setsTheCorrectDefaultValue_whenCurrentVersionIsMissing() throws {
         var dictionary = testData()
         dictionary.removeValue(forKey: "currentVersion")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(XCVersionGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to fail but tt didn't")
-        } catch {}
+        let subject = try decoder.decode(XCVersionGroup.self, from: data)
+        XCTAssertEqual(subject.currentVersion, "")
     }
 
-    func test_initFails_whenPathIsMissing() {
+    func test_setsTheCorrectDefaultValue_whenPathIsMissing() throws {
         var dictionary = testData()
         dictionary.removeValue(forKey: "path")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(XCVersionGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to fail but tt didn't")
-        } catch {}
+        let subject = try decoder.decode(XCVersionGroup.self, from: data)
+        XCTAssertEqual(subject.path, "")
     }
 
-    func test_initFails_whenSourceTreeIsMissing() {
+    func test_setsTheCorrectDefaultValue_whenSourceTreeIsMissing() throws {
         var dictionary = testData()
         dictionary.removeValue(forKey: "sourceTree")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(XCVersionGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to fail but tt didn't")
-        } catch {}
+        let subject = try decoder.decode(XCVersionGroup.self, from: data)
+        XCTAssertEqual(subject.sourceTree, .none)
     }
-
-    func test_initFails_whenVersionGroupTypeIsMissing() {
+    
+    func test_setsTheCorrectDefaultValue_whenVersionGroupTypeIsMissing() throws {
         var dictionary = testData()
         dictionary.removeValue(forKey: "versionGroupType")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
         let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(XCVersionGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to fail but tt didn't")
-        } catch {}
+        let subject = try decoder.decode(XCVersionGroup.self, from: data)
+        XCTAssertEqual(subject.versionGroupType, "")
     }
 
     // MARK: - Private


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/101

### Short description 📝
Assign default values to those values that are missing. By doing that, we allow developers open their projects and update them. To verify that the format is correct, they could use xclint and run it before saving their projects.

### Solution 📦
Update the objects init method and their respective tests.

### Implementation 👩‍💻👨‍💻
- [x] Update constructors.
- [x] Update tests.

### GIF
![gif](https://media.giphy.com/media/8OlT82jKm6Ugg/giphy.gif)
