### PR TITLE
Bring back BuildSettings typealias

### DIFF
--- a/Sources/xcproj/BuidlSettings.swift
+++ b/Sources/xcproj/BuidlSettings.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public typealias BuildSettings = [String: Any]

--- a/Sources/xcproj/XCBuildConfiguration.swift
+++ b/Sources/xcproj/XCBuildConfiguration.swift
@@ -9,7 +9,7 @@ public class XCBuildConfiguration: PBXObject, Hashable {
     public var baseConfigurationReference: String?
     
     /// A map of build settings.
-    public var buildSettings: [String: Any]
+    public var buildSettings: BuildSettings
     
     /// The configuration name.
     public var name: String
@@ -26,7 +26,7 @@ public class XCBuildConfiguration: PBXObject, Hashable {
     public init(reference: String,
                 name: String,
                 baseConfigurationReference: String? = nil,
-                buildSettings: [String: Any] = [:]) {
+                buildSettings: BuildSettings = [:]) {
         self.baseConfigurationReference = baseConfigurationReference
         self.buildSettings = buildSettings
         self.name = name

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -12,7 +12,7 @@ public class XCConfig {
     public var includes: [XCConfigInclude]
 
     /// Build settings
-    public var buildSettings: [String: Any]
+    public var buildSettings: BuildSettings
 
     // MARK: - Init
 
@@ -21,7 +21,7 @@ public class XCConfig {
     /// - Parameters:
     ///   - includes: all the .xcconfig file includes. The order determines how the values get overriden.
     ///   - dictionary: dictionary that contains the config.
-    public init(includes: [XCConfigInclude], buildSettings: [String: Any] = [:]) {
+    public init(includes: [XCConfigInclude], buildSettings: BuildSettings = [:]) {
         self.includes = includes
         self.buildSettings = buildSettings
     }


### PR DESCRIPTION
### Short description 📝
`BuildSettings` was a public typelias [being used](https://github.com/yonaskolb/XcodeGen/pull/85) from other libraries. By removing it we forced those libraries to update their implementations.

### Solution 📦
Bring it back since this kind of changes required a major update.

### Implementation 👩‍💻👨‍💻
- [x] Bring the typealias back and update the objects that were using it.

### GIF
![gif](https://media.giphy.com/media/11OJV2zUZRVL3y/giphy.gif)
