### PR TITLE
Stores the name without extension

### DIFF
--- a/Sources/xcproj/XCScheme.swift
+++ b/Sources/xcproj/XCScheme.swift
@@ -487,7 +487,7 @@ public class XCScheme {
         if !path.exists {
             throw XCSchemeError.notFound(path: path)
         }
-        name = path.lastComponent
+        name = path.lastComponentWithoutExtension
         let document = try AEXMLDocument(xml: try path.read())
         let scheme = document["Scheme"]
         lastUpgradeVersion = scheme.attributes["LastUpgradeVersion"]


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/112

### Short description 📝
Stores the `name` for `xcscheme` as `path.lastComponentWithoutExtension`

### GIF
![gif](https://media.giphy.com/media/14tvbepZ8vhU40/giphy.gif)
