### PR TITLE
Fix contributors link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ You can check out the documentation on the following [link](https://xcodeswift.g
 ## Contributors
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
-<a href="graphs/contributors"><img src="https://opencollective.com/xcproj/contributors.svg?width=890" /></a>
+<a href="https://github.com/xcodeswift/xcproj/graphs/contributors"><img src="https://opencollective.com/xcproj/contributors.svg?width=890" /></a>
 
 
 ## Backers


### PR DESCRIPTION
### Short description 📝
This pull request fixes the 404 error shown while clicking on the contributor's list in README.md
### Solution 📦
Instead of relative path mentioned in the README.md file actual path to contributors list is given as the fix.
