### PR TITLE
Add new init to initialize the workspace and the project with a path string

### DIFF
--- a/Sources/xcproj/XCWorkspace.swift
+++ b/Sources/xcproj/XCWorkspace.swift
@@ -25,6 +25,14 @@ public class XCWorkspace {
         }
         data = try XCWorkspace.Data(path: xcworkspaceDataPaths.first!)
     }
+    
+    /// Initializes the workspace with the path string.
+    ///
+    /// - Parameter pathString: path string.
+    /// - Throws: throws an error if the initialization fails.
+    public convenience init(pathString: String) throws {
+        try self.init(path: Path(pathString))
+    }
 
     /// Initializes the workspace with its properties.
     ///

--- a/Sources/xcproj/XcodeProj.swift
+++ b/Sources/xcproj/XcodeProj.swift
@@ -34,6 +34,10 @@ public class XcodeProj {
         let sharedDataPath = path + Path("xcshareddata")
         self.sharedData = try? XCSharedData(path: sharedDataPath)
     }
+    
+    public convenience init(pathString: String) throws {
+        try self.init(path: Path(pathString))
+    }
 
     /// Initializes the XCodeProj
     ///


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/121

### Short description 📝
The only init method available took a `PathKit.Path` value to initialize the model. That forced developers to import `PathKit` and pass `Path` values instead of just simply a `String` that represents the path.

### Solution 📦
Add a new convenience init that accepts a path `String`.

### GIF
![gif](https://media.giphy.com/media/VIPdgcooFJHtC/giphy.gif)
