### PR TITLE
Carthage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,7 @@ playground.xcworkspace
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+Carthage/Checkouts
 
 Carthage/Build
 

--- a/.gitignore
+++ b/.gitignore
@@ -146,9 +146,7 @@ playground.xcworkspace
 # Carthage
 #
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-Carthage/Checkouts
-
-Carthage/Build
+Carthage/
 
 # fastlane
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: generic
 osx_image: xcode9
 install:
 - bundle install
+before_script:
+- carthage update --platform iOS,macOS
 script:
 - bundle exec rake ci
 after_success:

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,2 @@
+github "tadija/AEXML" ~> 4.1.0
+github "kylef/PathKit" ~> 0.8.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "tadija/AEXML" ~> 4.1.0
+github "tadija/AEXML" "4.1.0"
 github "xcodeswift/PathKit" "f11da4713b9f78159f1102959642f02c57c9e6a8"

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -1,0 +1,752 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		BF1168848901 /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7776220701 /* PBXVariantGroup.swift */; };
+		BF1168848902 /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7776220701 /* PBXVariantGroup.swift */; };
+		BF1214569601 /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5186857101 /* CommentedString.swift */; };
+		BF1214569602 /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5186857101 /* CommentedString.swift */; };
+		BF1286225401 /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6357036901 /* KeyedDecodingContainer+Additions.swift */; };
+		BF1286225402 /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6357036901 /* KeyedDecodingContainer+Additions.swift */; };
+		BF1398928001 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2458458701 /* PBXProject.swift */; };
+		BF1398928002 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2458458701 /* PBXProject.swift */; };
+		BF1641641601 /* AEXML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR6447358001 /* AEXML.framework */; };
+		BF1993286801 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4384942301 /* PBXHeadersBuildPhase.swift */; };
+		BF1993286802 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4384942301 /* PBXHeadersBuildPhase.swift */; };
+		BF2033307201 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8483796101 /* PBXFileReference.swift */; };
+		BF2033307202 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8483796101 /* PBXFileReference.swift */; };
+		BF2241362001 /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6006730201 /* Dictionary+Extras.swift */; };
+		BF2241362002 /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6006730201 /* Dictionary+Extras.swift */; };
+		BF2311546501 /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3255351901 /* Bool+Extras.swift */; };
+		BF2311546502 /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3255351901 /* Bool+Extras.swift */; };
+		BF3107150401 /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5296652601 /* PBXProductType.swift */; };
+		BF3107150402 /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5296652601 /* PBXProductType.swift */; };
+		BF3167018201 /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8773023601 /* Decodable+Dictionary.swift */; };
+		BF3167018202 /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8773023601 /* Decodable+Dictionary.swift */; };
+		BF3202106901 = {isa = PBXBuildFile; fileRef = FR5099916101 /* xcproj_macOS.framework */; };
+		BF3222900001 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5190097701 /* PBXResourcesBuildPhase.swift */; };
+		BF3222900002 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5190097701 /* PBXResourcesBuildPhase.swift */; };
+		BF3650771501 /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5094343501 /* PBXTarget.swift */; };
+		BF3650771502 /* PBXTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5094343501 /* PBXTarget.swift */; };
+		BF3723071401 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6754770501 /* XCVersionGroup.swift */; };
+		BF3723071402 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6754770501 /* XCVersionGroup.swift */; };
+		BF3873193301 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3952162601 /* PBXAggregateTarget.swift */; };
+		BF3873193302 /* PBXAggregateTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3952162601 /* PBXAggregateTarget.swift */; };
+		BF3882936801 /* PBXFileElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1364894901 /* PBXFileElement.swift */; };
+		BF3882936802 /* PBXFileElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1364894901 /* PBXFileElement.swift */; };
+		BF4064216601 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2127460001 /* PBXNativeTarget.swift */; };
+		BF4064216602 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2127460001 /* PBXNativeTarget.swift */; };
+		BF4292481201 /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4811062301 /* XCSharedData.swift */; };
+		BF4292481202 /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4811062301 /* XCSharedData.swift */; };
+		BF4321991401 /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7045651001 /* PBXSourcesBuildPhase.swift */; };
+		BF4321991402 /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7045651001 /* PBXSourcesBuildPhase.swift */; };
+		BF4432284801 /* PBXBuildFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6980748501 /* PBXBuildFile.swift */; };
+		BF4432284802 /* PBXBuildFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6980748501 /* PBXBuildFile.swift */; };
+		BF4498090401 /* PBXReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1827232901 /* PBXReferenceProxy.swift */; };
+		BF4498090402 /* PBXReferenceProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1827232901 /* PBXReferenceProxy.swift */; };
+		BF4535722201 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4352207101 /* XCConfig.swift */; };
+		BF4535722202 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4352207101 /* XCConfig.swift */; };
+		BF4805463201 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR8873340702 /* PathKit.framework */; };
+		BF5094034701 /* PBXProj+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7428998701 /* PBXProj+Helpers.swift */; };
+		BF5094034702 /* PBXProj+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7428998701 /* PBXProj+Helpers.swift */; };
+		BF5156404201 /* String+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7128364401 /* String+Extras.swift */; };
+		BF5156404202 /* String+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7128364401 /* String+Extras.swift */; };
+		BF5295135101 /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2187351101 /* PBXShellScriptBuildPhase.swift */; };
+		BF5295135102 /* PBXShellScriptBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2187351101 /* PBXShellScriptBuildPhase.swift */; };
+		BF5377117101 /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR9617497901 /* PBXProjEncoder.swift */; };
+		BF5377117102 /* PBXProjEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR9617497901 /* PBXProjEncoder.swift */; };
+		BF5505389401 /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2287573101 /* PBXSourceTree.swift */; };
+		BF5505389402 /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2287573101 /* PBXSourceTree.swift */; };
+		BF5519296501 /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5076024901 /* Writable.swift */; };
+		BF5519296502 /* Writable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5076024901 /* Writable.swift */; };
+		BF5571338001 /* BuidlSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6464156701 /* BuidlSettings.swift */; };
+		BF5571338002 /* BuidlSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6464156701 /* BuidlSettings.swift */; };
+		BF5703401501 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR8873340701 /* PathKit.framework */; };
+		BF5923391201 /* PBXProjError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8121825001 /* PBXProjError.swift */; };
+		BF5923391202 /* PBXProjError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8121825001 /* PBXProjError.swift */; };
+		BF6269930301 /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4840718101 /* PlistValue.swift */; };
+		BF6269930302 /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4840718101 /* PlistValue.swift */; };
+		BF6518149701 /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8599247801 /* JSONDecoding.swift */; };
+		BF6518149702 /* JSONDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8599247801 /* JSONDecoding.swift */; };
+		BF6638647201 /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4128075701 /* PBXBuildPhase.swift */; };
+		BF6638647202 /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4128075701 /* PBXBuildPhase.swift */; };
+		BF6748394401 /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3171444701 /* XCScheme.swift */; };
+		BF6748394402 /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3171444701 /* XCScheme.swift */; };
+		BF6884424401 /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3140861801 /* XCConfigurationList.swift */; };
+		BF6884424402 /* XCConfigurationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3140861801 /* XCConfigurationList.swift */; };
+		BF7116108501 /* PBXProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8394611801 /* PBXProj.swift */; };
+		BF7116108502 /* PBXProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8394611801 /* PBXProj.swift */; };
+		BF7333567601 /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2671862701 /* XCWorkspace.swift */; };
+		BF7333567602 /* XCWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2671862701 /* XCWorkspace.swift */; };
+		BF7408709801 /* PBXFrameworksBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2771210001 /* PBXFrameworksBuildPhase.swift */; };
+		BF7408709802 /* PBXFrameworksBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2771210001 /* PBXFrameworksBuildPhase.swift */; };
+		BF7529047601 /* PBXGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3546471301 /* PBXGroup.swift */; };
+		BF7529047602 /* PBXGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3546471301 /* PBXGroup.swift */; };
+		BF7608155301 /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7796866701 /* XCBuildConfiguration.swift */; };
+		BF7608155302 /* XCBuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7796866701 /* XCBuildConfiguration.swift */; };
+		BF7696587101 /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5460675201 /* PBXCopyFilesBuildPhase.swift */; };
+		BF7696587102 /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5460675201 /* PBXCopyFilesBuildPhase.swift */; };
+		BF7755162901 = {isa = PBXBuildFile; fileRef = FR4163490801 /* xcproj_iOS.framework */; };
+		BF7832125601 /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8962043601 /* PBXContainerItemProxy.swift */; };
+		BF7832125602 /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8962043601 /* PBXContainerItemProxy.swift */; };
+		BF8332506301 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1312420901 /* XcodeProj.swift */; };
+		BF8332506302 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1312420901 /* XcodeProj.swift */; };
+		BF8380646601 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7552382101 /* PBXObject.swift */; };
+		BF8380646602 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7552382101 /* PBXObject.swift */; };
+		BF8826568101 /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1452498301 /* XCWorkspaceData.swift */; };
+		BF8826568102 /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1452498301 /* XCWorkspaceData.swift */; };
+		BF9036285501 /* AEXML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR6447358002 /* AEXML.framework */; };
+		BF9042303701 /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4602369901 /* BuildPhase.swift */; };
+		BF9042303702 /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4602369901 /* BuildPhase.swift */; };
+		BF9179674901 /* PBXTargetDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7414687801 /* PBXTargetDependency.swift */; };
+		BF9179674902 /* PBXTargetDependency.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7414687801 /* PBXTargetDependency.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		FR1312420901 /* XcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeProj.swift; sourceTree = "<group>"; };
+		FR1364894901 /* PBXFileElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFileElement.swift; sourceTree = "<group>"; };
+		FR1452498301 /* XCWorkspaceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceData.swift; sourceTree = "<group>"; };
+		FR1827232901 /* PBXReferenceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXReferenceProxy.swift; sourceTree = "<group>"; };
+		FR2127460001 /* PBXNativeTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXNativeTarget.swift; sourceTree = "<group>"; };
+		FR2187351101 /* PBXShellScriptBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXShellScriptBuildPhase.swift; sourceTree = "<group>"; };
+		FR2287573101 /* PBXSourceTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXSourceTree.swift; sourceTree = "<group>"; };
+		FR2458458701 /* PBXProject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProject.swift; sourceTree = "<group>"; };
+		FR2671862701 /* XCWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspace.swift; sourceTree = "<group>"; };
+		FR2771210001 /* PBXFrameworksBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFrameworksBuildPhase.swift; sourceTree = "<group>"; };
+		FR3140861801 /* XCConfigurationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCConfigurationList.swift; sourceTree = "<group>"; };
+		FR3171444701 /* XCScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCScheme.swift; sourceTree = "<group>"; };
+		FR3255351901 /* Bool+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bool+Extras.swift"; sourceTree = "<group>"; };
+		FR3546471301 /* PBXGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXGroup.swift; sourceTree = "<group>"; };
+		FR3952162601 /* PBXAggregateTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXAggregateTarget.swift; sourceTree = "<group>"; };
+		FR4128075701 /* PBXBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildPhase.swift; sourceTree = "<group>"; };
+		FR4163490801 /* xcproj_iOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = xcproj_iOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR4352207101 /* XCConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCConfig.swift; sourceTree = "<group>"; };
+		FR4384942301 /* PBXHeadersBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXHeadersBuildPhase.swift; sourceTree = "<group>"; };
+		FR4602369901 /* BuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildPhase.swift; sourceTree = "<group>"; };
+		FR4811062301 /* XCSharedData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCSharedData.swift; sourceTree = "<group>"; };
+		FR4840718101 /* PlistValue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistValue.swift; sourceTree = "<group>"; };
+		FR5076024901 /* Writable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Writable.swift; sourceTree = "<group>"; };
+		FR5094343501 /* PBXTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXTarget.swift; sourceTree = "<group>"; };
+		FR5099916101 /* xcproj_macOS.framework */ = {isa = PBXFileReference; explicitFileType = framework; includeInIndex = 0; lastKnownFileType = wrapper.framework; path = xcproj_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FR5186857101 /* CommentedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentedString.swift; sourceTree = "<group>"; };
+		FR5190097701 /* PBXResourcesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXResourcesBuildPhase.swift; sourceTree = "<group>"; };
+		FR5296652601 /* PBXProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProductType.swift; sourceTree = "<group>"; };
+		FR5460675201 /* PBXCopyFilesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXCopyFilesBuildPhase.swift; sourceTree = "<group>"; };
+		FR6006730201 /* Dictionary+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
+		FR6357036901 /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
+		FR6447358001 /* AEXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AEXML.framework; sourceTree = "<group>"; };
+		FR6447358002 /* AEXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AEXML.framework; sourceTree = "<group>"; };
+		FR6464156701 /* BuidlSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuidlSettings.swift; sourceTree = "<group>"; };
+		FR6754770501 /* XCVersionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCVersionGroup.swift; sourceTree = "<group>"; };
+		FR6980748501 /* PBXBuildFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildFile.swift; sourceTree = "<group>"; };
+		FR7045651001 /* PBXSourcesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXSourcesBuildPhase.swift; sourceTree = "<group>"; };
+		FR7128364401 /* String+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extras.swift"; sourceTree = "<group>"; };
+		FR7414687801 /* PBXTargetDependency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXTargetDependency.swift; sourceTree = "<group>"; };
+		FR7428998701 /* PBXProj+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProj+Helpers.swift"; sourceTree = "<group>"; };
+		FR7552382101 /* PBXObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXObject.swift; sourceTree = "<group>"; };
+		FR7776220701 /* PBXVariantGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXVariantGroup.swift; sourceTree = "<group>"; };
+		FR7796866701 /* XCBuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCBuildConfiguration.swift; sourceTree = "<group>"; };
+		FR8121825001 /* PBXProjError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProjError.swift; sourceTree = "<group>"; };
+		FR8394611801 /* PBXProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProj.swift; sourceTree = "<group>"; };
+		FR8483796101 /* PBXFileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFileReference.swift; sourceTree = "<group>"; };
+		FR8599247801 /* JSONDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoding.swift; sourceTree = "<group>"; };
+		FR8773023601 /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Dictionary.swift"; sourceTree = "<group>"; };
+		FR8873340701 /* PathKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PathKit.framework; sourceTree = "<group>"; };
+		FR8873340702 /* PathKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PathKit.framework; sourceTree = "<group>"; };
+		FR8962043601 /* PBXContainerItemProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXContainerItemProxy.swift; sourceTree = "<group>"; };
+		FR9617497901 /* PBXProjEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProjEncoder.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		FBP416349001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF5703401501 /* PathKit.framework in Frameworks */,
+				BF1641641601 /* AEXML.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FBP509991601 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF4805463201 /* PathKit.framework in Frameworks */,
+				BF9036285501 /* AEXML.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		G19527407101 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				G28836901501 /* Carthage */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		G28836901501 /* Carthage */ = {
+			isa = PBXGroup;
+			children = (
+				G47994500501 /* iOS */,
+				G47994500502 /* Mac */,
+			);
+			name = Carthage;
+			path = Carthage/Build;
+			sourceTree = "<group>";
+		};
+		G47994500501 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				FR6447358001 /* AEXML.framework */,
+				FR8873340701 /* PathKit.framework */,
+			);
+			name = iOS;
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		G47994500502 /* Mac */ = {
+			isa = PBXGroup;
+			children = (
+				FR6447358002 /* AEXML.framework */,
+				FR8873340702 /* PathKit.framework */,
+			);
+			name = Mac;
+			path = Mac;
+			sourceTree = "<group>";
+		};
+		G48093636701 /* xcproj */ = {
+			isa = PBXGroup;
+			children = (
+				FR3255351901 /* Bool+Extras.swift */,
+				FR6464156701 /* BuidlSettings.swift */,
+				FR4602369901 /* BuildPhase.swift */,
+				FR5186857101 /* CommentedString.swift */,
+				FR8773023601 /* Decodable+Dictionary.swift */,
+				FR6006730201 /* Dictionary+Extras.swift */,
+				FR8599247801 /* JSONDecoding.swift */,
+				FR6357036901 /* KeyedDecodingContainer+Additions.swift */,
+				FR3952162601 /* PBXAggregateTarget.swift */,
+				FR6980748501 /* PBXBuildFile.swift */,
+				FR4128075701 /* PBXBuildPhase.swift */,
+				FR8962043601 /* PBXContainerItemProxy.swift */,
+				FR5460675201 /* PBXCopyFilesBuildPhase.swift */,
+				FR1364894901 /* PBXFileElement.swift */,
+				FR8483796101 /* PBXFileReference.swift */,
+				FR2771210001 /* PBXFrameworksBuildPhase.swift */,
+				FR3546471301 /* PBXGroup.swift */,
+				FR4384942301 /* PBXHeadersBuildPhase.swift */,
+				FR2127460001 /* PBXNativeTarget.swift */,
+				FR7552382101 /* PBXObject.swift */,
+				FR5296652601 /* PBXProductType.swift */,
+				FR7428998701 /* PBXProj+Helpers.swift */,
+				FR8394611801 /* PBXProj.swift */,
+				FR9617497901 /* PBXProjEncoder.swift */,
+				FR8121825001 /* PBXProjError.swift */,
+				FR2458458701 /* PBXProject.swift */,
+				FR1827232901 /* PBXReferenceProxy.swift */,
+				FR5190097701 /* PBXResourcesBuildPhase.swift */,
+				FR2187351101 /* PBXShellScriptBuildPhase.swift */,
+				FR2287573101 /* PBXSourceTree.swift */,
+				FR7045651001 /* PBXSourcesBuildPhase.swift */,
+				FR5094343501 /* PBXTarget.swift */,
+				FR7414687801 /* PBXTargetDependency.swift */,
+				FR7776220701 /* PBXVariantGroup.swift */,
+				FR4840718101 /* PlistValue.swift */,
+				FR7128364401 /* String+Extras.swift */,
+				FR5076024901 /* Writable.swift */,
+				FR7796866701 /* XCBuildConfiguration.swift */,
+				FR4352207101 /* XCConfig.swift */,
+				FR3140861801 /* XCConfigurationList.swift */,
+				FR3171444701 /* XCScheme.swift */,
+				FR4811062301 /* XCSharedData.swift */,
+				FR6754770501 /* XCVersionGroup.swift */,
+				FR2671862701 /* XCWorkspace.swift */,
+				FR1452498301 /* XCWorkspaceData.swift */,
+				FR1312420901 /* XcodeProj.swift */,
+			);
+			name = xcproj;
+			path = Sources/xcproj;
+			sourceTree = "<group>";
+		};
+		G84487712001 = {
+			isa = PBXGroup;
+			children = (
+				G48093636701 /* xcproj */,
+				G86202385201 /* Products */,
+				G19527407101 /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		G86202385201 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				FR4163490801 /* xcproj_iOS.framework */,
+				FR5099916101 /* xcproj_macOS.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		HBP416349001 /* Frameworks */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		HBP509991601 /* Frameworks */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		NT4163490801 /* xcproj_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = XCCL41634901 /* Build configuration list for PBXNativeTarget "xcproj_iOS" */;
+			buildPhases = (
+				SBP416349001 /* Sources */,
+				RBP416349001 /* Resources */,
+				HBP416349001 /* Headers */,
+				FBP416349001 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = xcproj_iOS;
+			productReference = FR4163490801;
+			productType = "com.apple.product-type.framework";
+		};
+		NT5099916101 /* xcproj_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = XCCL50999101 /* Build configuration list for PBXNativeTarget "xcproj_macOS" */;
+			buildPhases = (
+				SBP509991601 /* Sources */,
+				RBP509991601 /* Resources */,
+				HBP509991601 /* Headers */,
+				FBP509991601 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = xcproj_macOS;
+			productReference = FR5099916101;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		P28836901501 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0900;
+			};
+			buildConfigurationList = XCCL28836901 /* Build configuration list for PBXProject "Carthage" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = G84487712001;
+			targets = (
+				NT4163490801 /* xcproj_iOS */,
+				NT5099916101 /* xcproj_macOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		RBP416349001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		RBP509991601 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		SBP416349001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF2311546501 /* Bool+Extras.swift in Sources */,
+				BF5571338001 /* BuidlSettings.swift in Sources */,
+				BF9042303701 /* BuildPhase.swift in Sources */,
+				BF1214569601 /* CommentedString.swift in Sources */,
+				BF3167018201 /* Decodable+Dictionary.swift in Sources */,
+				BF2241362001 /* Dictionary+Extras.swift in Sources */,
+				BF6518149701 /* JSONDecoding.swift in Sources */,
+				BF1286225401 /* KeyedDecodingContainer+Additions.swift in Sources */,
+				BF3873193301 /* PBXAggregateTarget.swift in Sources */,
+				BF4432284801 /* PBXBuildFile.swift in Sources */,
+				BF6638647201 /* PBXBuildPhase.swift in Sources */,
+				BF7832125601 /* PBXContainerItemProxy.swift in Sources */,
+				BF7696587101 /* PBXCopyFilesBuildPhase.swift in Sources */,
+				BF3882936801 /* PBXFileElement.swift in Sources */,
+				BF2033307201 /* PBXFileReference.swift in Sources */,
+				BF7408709801 /* PBXFrameworksBuildPhase.swift in Sources */,
+				BF7529047601 /* PBXGroup.swift in Sources */,
+				BF1993286801 /* PBXHeadersBuildPhase.swift in Sources */,
+				BF4064216601 /* PBXNativeTarget.swift in Sources */,
+				BF8380646601 /* PBXObject.swift in Sources */,
+				BF3107150401 /* PBXProductType.swift in Sources */,
+				BF5094034701 /* PBXProj+Helpers.swift in Sources */,
+				BF7116108501 /* PBXProj.swift in Sources */,
+				BF5377117101 /* PBXProjEncoder.swift in Sources */,
+				BF5923391201 /* PBXProjError.swift in Sources */,
+				BF1398928001 /* PBXProject.swift in Sources */,
+				BF4498090401 /* PBXReferenceProxy.swift in Sources */,
+				BF3222900001 /* PBXResourcesBuildPhase.swift in Sources */,
+				BF5295135101 /* PBXShellScriptBuildPhase.swift in Sources */,
+				BF5505389401 /* PBXSourceTree.swift in Sources */,
+				BF4321991401 /* PBXSourcesBuildPhase.swift in Sources */,
+				BF3650771501 /* PBXTarget.swift in Sources */,
+				BF9179674901 /* PBXTargetDependency.swift in Sources */,
+				BF1168848901 /* PBXVariantGroup.swift in Sources */,
+				BF6269930301 /* PlistValue.swift in Sources */,
+				BF5156404201 /* String+Extras.swift in Sources */,
+				BF5519296501 /* Writable.swift in Sources */,
+				BF7608155301 /* XCBuildConfiguration.swift in Sources */,
+				BF4535722201 /* XCConfig.swift in Sources */,
+				BF6884424401 /* XCConfigurationList.swift in Sources */,
+				BF6748394401 /* XCScheme.swift in Sources */,
+				BF4292481201 /* XCSharedData.swift in Sources */,
+				BF3723071401 /* XCVersionGroup.swift in Sources */,
+				BF7333567601 /* XCWorkspace.swift in Sources */,
+				BF8826568101 /* XCWorkspaceData.swift in Sources */,
+				BF8332506301 /* XcodeProj.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		SBP509991601 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BF2311546502 /* Bool+Extras.swift in Sources */,
+				BF5571338002 /* BuidlSettings.swift in Sources */,
+				BF9042303702 /* BuildPhase.swift in Sources */,
+				BF1214569602 /* CommentedString.swift in Sources */,
+				BF3167018202 /* Decodable+Dictionary.swift in Sources */,
+				BF2241362002 /* Dictionary+Extras.swift in Sources */,
+				BF6518149702 /* JSONDecoding.swift in Sources */,
+				BF1286225402 /* KeyedDecodingContainer+Additions.swift in Sources */,
+				BF3873193302 /* PBXAggregateTarget.swift in Sources */,
+				BF4432284802 /* PBXBuildFile.swift in Sources */,
+				BF6638647202 /* PBXBuildPhase.swift in Sources */,
+				BF7832125602 /* PBXContainerItemProxy.swift in Sources */,
+				BF7696587102 /* PBXCopyFilesBuildPhase.swift in Sources */,
+				BF3882936802 /* PBXFileElement.swift in Sources */,
+				BF2033307202 /* PBXFileReference.swift in Sources */,
+				BF7408709802 /* PBXFrameworksBuildPhase.swift in Sources */,
+				BF7529047602 /* PBXGroup.swift in Sources */,
+				BF1993286802 /* PBXHeadersBuildPhase.swift in Sources */,
+				BF4064216602 /* PBXNativeTarget.swift in Sources */,
+				BF8380646602 /* PBXObject.swift in Sources */,
+				BF3107150402 /* PBXProductType.swift in Sources */,
+				BF5094034702 /* PBXProj+Helpers.swift in Sources */,
+				BF7116108502 /* PBXProj.swift in Sources */,
+				BF5377117102 /* PBXProjEncoder.swift in Sources */,
+				BF5923391202 /* PBXProjError.swift in Sources */,
+				BF1398928002 /* PBXProject.swift in Sources */,
+				BF4498090402 /* PBXReferenceProxy.swift in Sources */,
+				BF3222900002 /* PBXResourcesBuildPhase.swift in Sources */,
+				BF5295135102 /* PBXShellScriptBuildPhase.swift in Sources */,
+				BF5505389402 /* PBXSourceTree.swift in Sources */,
+				BF4321991402 /* PBXSourcesBuildPhase.swift in Sources */,
+				BF3650771502 /* PBXTarget.swift in Sources */,
+				BF9179674902 /* PBXTargetDependency.swift in Sources */,
+				BF1168848902 /* PBXVariantGroup.swift in Sources */,
+				BF6269930302 /* PlistValue.swift in Sources */,
+				BF5156404202 /* String+Extras.swift in Sources */,
+				BF5519296502 /* Writable.swift in Sources */,
+				BF7608155302 /* XCBuildConfiguration.swift in Sources */,
+				BF4535722202 /* XCConfig.swift in Sources */,
+				BF6884424402 /* XCConfigurationList.swift in Sources */,
+				BF6748394402 /* XCScheme.swift in Sources */,
+				BF4292481202 /* XCSharedData.swift in Sources */,
+				BF3723071402 /* XCVersionGroup.swift in Sources */,
+				BF7333567602 /* XCWorkspace.swift in Sources */,
+				BF8826568102 /* XCWorkspaceData.swift in Sources */,
+				BF8332506302 /* XcodeProj.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		XCBC19610601 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = swift.xcode.xcproj;
+				PRODUCT_NAME = xcproj;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		XCBC20650601 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = swift.xcode.xcproj;
+				PRODUCT_NAME = xcproj;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		XCBC37217301 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/Mac",
+				);
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
+				PRODUCT_BUNDLE_IDENTIFIER = swift.xcode.xcproj;
+				PRODUCT_NAME = xcproj;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		XCBC40831401 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = swift.xcode.xcproj;
+				PRODUCT_NAME = xcproj;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		XCBC47994501 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		XCBC88111401 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		XCCL28836901 /* Build configuration list for PBXProject "Carthage" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				XCBC47994501 /* Debug */,
+				XCBC88111401 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		XCCL41634901 /* Build configuration list for PBXNativeTarget "xcproj_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				XCBC20650601 /* Debug */,
+				XCBC40831401 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+		XCCL50999101 /* Build configuration list for PBXNativeTarget "xcproj_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				XCBC19610601 /* Debug */,
+				XCBC37217301 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = "";
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = P28836901501 /* Project object */;
+}

--- a/Carthage.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Carthage.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Workspace version="1.0">
+	<FileRef location="self:" />
+</Workspace>

--- a/Carthage.xcodeproj/xcshareddata/xcschemes/xcproj_iOS.xcscheme
+++ b/Carthage.xcodeproj/xcshareddata/xcschemes/xcproj_iOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NT4163490801"
+               BuildableName = "xcproj.framework"
+               BlueprintName = "xcproj_iOS"
+               ReferencedContainer = "container:Carthage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT4163490801"
+            BuildableName = "xcproj.framework"
+            BlueprintName = "xcproj_iOS"
+            ReferencedContainer = "container:Carthage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT4163490801"
+            BuildableName = "xcproj.framework"
+            BlueprintName = "xcproj_iOS"
+            ReferencedContainer = "container:Carthage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Carthage.xcodeproj/xcshareddata/xcschemes/xcproj_macOS.xcscheme
+++ b/Carthage.xcodeproj/xcshareddata/xcschemes/xcproj_macOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0900"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "NT5099916101"
+               BuildableName = "xcproj.framework"
+               BlueprintName = "xcproj_macOS"
+               ReferencedContainer = "container:Carthage.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT5099916101"
+            BuildableName = "xcproj.framework"
+            BlueprintName = "xcproj_macOS"
+            ReferencedContainer = "container:Carthage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "NT5099916101"
+            BuildableName = "xcproj.framework"
+            BlueprintName = "xcproj_macOS"
+            ReferencedContainer = "container:Carthage.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/README.md
+++ b/README.md
@@ -82,8 +82,16 @@ https://github.com/xcodeswift/xcproj.git
 
 Edit your `Podfile` and specify the dependency:
 
-```bash
+```ruby
 pod "xcproj"
+```
+
+#### Using [Carthage](https://github.com/carthage)
+
+Edit your `Cartfile` and specify the dependency:
+
+```bash
+github "xcodeswift/xcproj"
 ```
 
 > Note: xcproj is only available for macOS and iOS projects.

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'colorize'
 require 'fileutils'
 
 DESTINATION = "platform=iOS Simulator,name=iPhone 6,OS=11.0"
+XCODEGEN_VERSION = "1.3.0"
 
 def generate_docs
   print "Executing tests"
@@ -68,7 +69,7 @@ end
 
 def generate_carthage_project
   throw "Mint is necessary. Make sure it's installed in your system" unless command?("mint")
-  sh "mint run yonaskolb/xcodegen@1.3.0"
+  sh "mint run yonaskolb/xcodegen@#{XCODEGEN_VERSION}"
 end
 
 def print(message)

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require 'semantic'
 require 'colorize'
 require 'fileutils'
 
-DESTINATION = "platform=iOS Simulator,name=iPhone 6,OS=11.0.1"
+DESTINATION = "platform=iOS Simulator,name=iPhone 6,OS=11.0"
 
 def generate_docs
   print "Executing tests"

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,11 @@
+name: Carthage
+targets:
+  xcproj:
+    type: framework
+    platform: [iOS, macOS]
+    sources: Sources/xcproj
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: swift.xcode.xcproj
+    dependencies:
+      - carthage: PathKit
+      - carthage: AEXML


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/41

### Short description 📝
`xcproj` cannot be linked from another project using Carthage. To support it, the repository needs to expose a project with targets that compile the framework for all the supported platforms.

### Solution 📦
Use [xcodegen](https://github.com/yonaskolb/xcodegen) to generate the Carthage project as part of the release process.

### Implementation 👩‍💻👨‍💻
- [x] Define `project.yml`.
- [x] Add Carthage support to PathKit. **blocker**
- [x] Update the release process.
- [x] Update ci task to validates that the project generated for Carthage is valid.

### GIF
![gif](https://media.giphy.com/media/3ohhwnpoYUtExNvWrm/giphy.gif)
