### PR TITLE
Activate several doc comments

### DIFF
--- a/Sources/xcproj/PBXAggregateTarget.swift
+++ b/Sources/xcproj/PBXAggregateTarget.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for a build target that aggregates several others.
+/// This is the element for a build target that aggregates several others.
 public class PBXAggregateTarget: PBXTarget {
 
 }

--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This element indicate a file reference that is used in a PBXBuildPhase (either as an include or resource).
+/// This element indicates a file reference that is used in a PBXBuildPhase (either as an include or resource).
 public class PBXBuildFile: PBXObject, Hashable {
 
     // MARK: - Attributes

--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// An absctract class for all the build phase objects
+/// An absctract class for all the build phase objects
 public class PBXBuildPhase: PBXObject {
 
     /// Element build action mask.

--- a/Sources/xcproj/PBXContainerItemProxy.swift
+++ b/Sources/xcproj/PBXContainerItemProxy.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for to decorate a target item.
+/// This is the element to decorate a target item.
 public class PBXContainerItemProxy: PBXObject, Hashable {
 
     public enum ProxyType: UInt, Decodable {

--- a/Sources/xcproj/PBXCopyFilesBuildPhase.swift
+++ b/Sources/xcproj/PBXCopyFilesBuildPhase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for the copy file build phase.
+/// This is the element for the copy file build phase.
 public class PBXCopyFilesBuildPhase: PBXBuildPhase, Hashable {
 
     public enum SubFolder: UInt, Decodable {

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This element is an abstract parent for file and group elements.
+/// This element is an abstract parent for file and group elements.
 public class PBXFileElement: PBXObject, Hashable {
     
     // MARK: - Attributes

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -1,8 +1,8 @@
 import Foundation
 import PathKit
 
-//  A PBXFileReference is used to track every external file referenced by 
-//  the project: source files, resource files, libraries, generated application files, and so on.
+///  A PBXFileReference is used to track every external file referenced by
+///  the project: source files, resource files, libraries, generated application files, and so on.
 public class PBXFileReference: PBXObject, Hashable {
  
     // MARK: - Attributes

--- a/Sources/xcproj/PBXFrameworksBuildPhase.swift
+++ b/Sources/xcproj/PBXFrameworksBuildPhase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for the framewrok link build phase.
+/// This is the element for the framework link build phase.
 public class PBXFrameworksBuildPhase: PBXBuildPhase, Hashable {
     
     public static func == (lhs: PBXFrameworksBuildPhase,

--- a/Sources/xcproj/PBXHeadersBuildPhase.swift
+++ b/Sources/xcproj/PBXHeadersBuildPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PathKit
 
-// This is the element for the framewrok link build phase.
+/// This is the element for the framework headers build phase.
 public class PBXHeadersBuildPhase: PBXBuildPhase, Hashable {
     
     public static func == (lhs: PBXHeadersBuildPhase,

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PathKit
 
-/// It represents a .pbxproj file
+/// Represents a .pbxproj file
 public class PBXProj: Decodable {
 
     // MARK: - Properties

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -1,44 +1,43 @@
 import Foundation
 
-// This is the element for a build target that produces a binary content (application or library).
 public class PBXProject: PBXObject, Hashable {
     
     // MARK: - Attributes
   
-    // xcodeproj's name
+    /// xcodeproj's name
     public var name: String
 
-    // The object is a reference to a XCConfigurationList element.
+    /// The object is a reference to a XCConfigurationList element.
     public var buildConfigurationList: String
     
-    // A string representation of the XcodeCompatibilityVersion.
+    /// A string representation of the XcodeCompatibilityVersion.
     public var compatibilityVersion: String
     
-    // The region of development.
+    /// The region of development.
     public var developmentRegion: String?
     
-    // Whether file encodings have been scanned.
+    /// Whether file encodings have been scanned.
     public var hasScannedForEncodings: Int?
     
-    // The known regions for localized files.
+    /// The known regions for localized files.
     public var knownRegions: [String]
     
-    // The object is a reference to a PBXGroup element.
+    /// The object is a reference to a PBXGroup element.
     public var mainGroup: String
     
-    // The object is a reference to a PBXGroup element.
+    /// The object is a reference to a PBXGroup element.
     public var productRefGroup: String?
     
-    // The relative path of the project.
+    /// The relative path of the project.
     public var projectDirPath: String?
     
     /// Project references.
     public var projectReferences: [Any]
     
-    // The relative root path of the project.
+    /// The relative root path of the project.
     public var projectRoot: String?
     
-    // The objects are a reference to a PBXTarget element.
+    /// The objects are a reference to a PBXTarget element.
     public var targets: [String]
     
     /// Project attributes.

--- a/Sources/xcproj/PBXReferenceProxy.swift
+++ b/Sources/xcproj/PBXReferenceProxy.swift
@@ -7,16 +7,16 @@ public class PBXReferenceProxy: PBXObject, Hashable {
     
     // MARK: - Attributes
     
-    // Element file type
+    /// Element file type
     public var fileType: String?
     
-    // Element path.
+    /// Element path.
     public var path: String?
     
-    // Element remote reference.
+    /// Element remote reference.
     public var remoteRef: String?
     
-    // Element source tree.
+    /// Element source tree.
     public var sourceTree: PBXSourceTree?
     
     // MARK: - Init

--- a/Sources/xcproj/PBXResourcesBuildPhase.swift
+++ b/Sources/xcproj/PBXResourcesBuildPhase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for the resources copy build phase.
+/// This is the element for the resources copy build phase.
 public class PBXResourcesBuildPhase: PBXBuildPhase, Hashable {
     
     public static func == (lhs: PBXResourcesBuildPhase,

--- a/Sources/xcproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcproj/PBXShellScriptBuildPhase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for the resources copy build phase.
+/// This is the element for the shell script build phase.
 public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
 
     // MARK: - Attributes

--- a/Sources/xcproj/PBXSourceTree.swift
+++ b/Sources/xcproj/PBXSourceTree.swift
@@ -1,6 +1,7 @@
 import Foundation
 
-// Specifies source trees for files
+/// Specifies source trees for files
+/// Corresponds to the "Location" dropdown in Xcode's File Inspector
 public enum PBXSourceTree: String, Hashable, Decodable {
     case none = ""
     case absolute = "<absolute>"

--- a/Sources/xcproj/PBXSourcesBuildPhase.swift
+++ b/Sources/xcproj/PBXSourcesBuildPhase.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for the sources compilation build phase.
+/// This is the element for the sources compilation build phase.
 public class PBXSourcesBuildPhase: PBXBuildPhase, Hashable {
     
     // MARK: - Hashable

--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This element is an abstract parent for specialized targets.
+/// This element is an abstract parent for specialized targets.
 public class PBXTarget: PBXObject, Hashable {
 
     /// Target build configuration list.

--- a/Sources/xcproj/PBXTargetDependency.swift
+++ b/Sources/xcproj/PBXTargetDependency.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for referencing other target through content proxies.
+/// This is the element for referencing other targets through content proxies.
 public class PBXTargetDependency: PBXObject, Hashable {
     
     // MARK: - Attributes

--- a/Sources/xcproj/PBXVariantGroup.swift
+++ b/Sources/xcproj/PBXVariantGroup.swift
@@ -5,13 +5,13 @@ public class PBXVariantGroup: PBXObject, Hashable {
 
     // MARK: - Attributes
 
-    // The objects are a reference to a PBXFileElement element
+    /// The objects are a reference to a PBXFileElement element
     public var children: [String]
 
-    // The filename
+    /// The filename
     public var name: String?
 
-    // Variant group source tree.
+    /// Variant group source tree.
     public var sourceTree: PBXSourceTree?
 
     // MARK: - Init

--- a/Sources/xcproj/XCBuildConfiguration.swift
+++ b/Sources/xcproj/XCBuildConfiguration.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for listing build configurations.
+/// This is the element for listing build configurations.
 public class XCBuildConfiguration: PBXObject, Hashable {
    
     // MARK: - Attributes

--- a/Sources/xcproj/XCConfigurationList.swift
+++ b/Sources/xcproj/XCConfigurationList.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-// This is the element for listing build configurations.
+/// This is the element for listing build configurations.
 public class XCConfigurationList: PBXObject, Hashable {
     
     // MARK: - Attributes

--- a/Sources/xcproj/XCVersionGroup.swift
+++ b/Sources/xcproj/XCVersionGroup.swift
@@ -1,8 +1,8 @@
 import Foundation
 import PathKit
 
-// Group that contains multiple files references to the different versions of a resource.
-// Used to contain the different versions of a xcdatamodel
+/// Group that contains multiple files references to the different versions of a resource.
+/// Used to contain the different versions of a xcdatamodel
 public class XCVersionGroup: PBXObject, Hashable {
 
     // MARK: - Attributes

--- a/Sources/xcproj/XCWorkspaceData.swift
+++ b/Sources/xcproj/XCWorkspaceData.swift
@@ -96,7 +96,7 @@ public extension XCWorkspace {
 
         }
 
-        /// MARK: - Attributes
+        // MARK: - Attributes
 
         /// References to the workspace projects
         public var references: [FileRef]

--- a/Sources/xcproj/XcodeProj.swift
+++ b/Sources/xcproj/XcodeProj.swift
@@ -6,7 +6,7 @@ public class XcodeProj {
 
     // MARK: - Properties
 
-    // Project workspace
+    /// Project workspace
     public var workspace: XCWorkspace
 
     /// .pbxproj representatino


### PR DESCRIPTION
Turns several several `//` comments that probably ought to be `///` doc comments into the latter.

Also fixes some copy & paste errors and typos.