### PR TITLE
Fix decoding fileEncoding

### DIFF
--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -95,7 +95,8 @@ public class PBXFileReference: PBXObject, Hashable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.fileEncoding = try container.decodeIfPresent(.fileEncoding)
+        let fileEncodingString: String? = try container.decodeIfPresent(.fileEncoding)
+        self.fileEncoding = fileEncodingString.flatMap(Int.init)
         self.explicitFileType = try container.decodeIfPresent(.explicitFileType)
         self.lastKnownFileType = try container.decodeIfPresent(.lastKnownFileType)
         let includeInIndexString: String? = try container.decodeIfPresent(.includeInIndex)


### PR DESCRIPTION
Since the old-style plist format that's used for .pbxproj files seems to encode only Strings (and Arrays and Dictionaries) and does not preserve number types, we have to decode fileEncoding to
a String first.

For most projects where files are UTF-8 encoded the corresponding `fileEncoding = 4` is omitted.
Thus this bug wouldn't manifest with many regular and recent projects.

In certain cases (like using the search & replace preview from Xcode 8 and prior) Xcode did add `fileEncoding = 4` explicitly. I had some .pbxproj files around where this was the case and there the decoding failed.