### PR TITLE
Rename PBXProjWriter => PBXProjEncoder

### DIFF
--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -98,8 +98,8 @@ extension PBXProj {
 extension PBXProj: Writable {
     
     public func write(path: Path, override: Bool) throws {
-        let writer = PBXProjWriter()
-        let output = writer.write(proj: self)
+        let encoder = PBXProjEncoder()
+        let output = encoder.encode(proj: self)
         if override && path.exists {
             try path.delete()
         }

--- a/Sources/xcproj/PBXProjEncoder.swift
+++ b/Sources/xcproj/PBXProjEncoder.swift
@@ -10,14 +10,14 @@ extension PlistSerializable {
     var multiline: Bool { return true }
 }
 
-/// Writes your PBXProj files
-class PBXProjWriter {
+/// Encodes your PBXProj files to String
+class PBXProjEncoder {
     
     var indent: UInt = 0
     var output: String = ""
     var multiline: Bool = true
     
-    func write(proj: PBXProj) -> String {
+    func encode(proj: PBXProj) -> String {
         writeUtf8()
         writeNewLine()
         writeDictionaryStart()

--- a/Tests/xcprojTests/PBXProjWriterSpec.swift
+++ b/Tests/xcprojTests/PBXProjWriterSpec.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import xcproj
 
-class PBXProjWriterSpec: XCTestCase {
+class PBXProjEncoderSpec: XCTestCase {
 
     func test_dictionaryPlistValue_returnsTheCorrectValue() {
         let dictionary: [String: Any] = [


### PR DESCRIPTION
### Short description 📝
`PBXProjWriter` was not really writing anything.

### Solution 📦
Renamed to suitable name.

### GIF
![LGTM](https://media3.giphy.com/media/Q0kedzrw2oUTK/giphy.gif)