### PR TITLE
Add method for writing with path string

### DIFF
--- a/Sources/xcproj/Writable.swift
+++ b/Sources/xcproj/Writable.swift
@@ -11,4 +11,18 @@ public protocol Writable {
     /// - Throws: writing error if something goes wrong.
     func write(path: Path, override: Bool) throws
 
+    /// Writes the object that conforms the protocol.
+    ///
+    /// - Parameter pathString: The path string to write to
+    /// - Parameter override: True if the content should be overriden if it already exists.
+    /// - Throws: writing error if something goes wrong.
+    func write(pathString: String, override: Bool) throws
+}
+
+extension Writable {
+
+    public func write(pathString: String, override: Bool) throws {
+        let path = Path(pathString)
+        try write(path: path, override: override)
+    }
 }


### PR DESCRIPTION
### Short description 📝
Extend `Writable` protocol with `String` as path.

### Solution 📦
I already told about `Path`s here: #121. I added a new method for convenience writing w/o Path framework imports and hardcoded paths.

### Implementation 👩‍💻👨‍💻
I added a new method with default implementation to prevent code duplication. What do you think about it? 
