### PR TITLE
Default buildPhase buildActionMask

### DIFF
--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// An absctract class for all the build phase objects
 public class PBXBuildPhase: PBXObject {
+    
+    /// Default build action mask.
+    public static let defaultBuildActionMask: UInt = 2147483647
 
     /// Element build action mask.
     public var buildActionMask: UInt?
@@ -14,7 +17,7 @@ public class PBXBuildPhase: PBXObject {
 
     public init(reference: String,
                 files: [String] = [],
-                buildActionMask: UInt? = nil,
+                buildActionMask: UInt? = defaultBuildActionMask,
                 runOnlyForDeploymentPostprocessing: UInt? = nil) {
         self.files = files
         self.buildActionMask = buildActionMask
@@ -34,7 +37,7 @@ public class PBXBuildPhase: PBXObject {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let buildActionMaskString: String? = try container.decodeIfPresent(.buildActionMask)
-        self.buildActionMask = buildActionMaskString.flatMap(UInt.init)
+        self.buildActionMask = buildActionMaskString.flatMap(UInt.init) ?? PBXBuildPhase.defaultBuildActionMask
         self.files = try container.decodeIfPresent(.files) ?? []
         let runOnlyForDeploymentPostprocessingString: String? = try container.decodeIfPresent(.runOnlyForDeploymentPostprocessing)
         self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessingString.flatMap(UInt.init)

--- a/Tests/xcprojTests/PBXSourcesBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXSourcesBuildPhaseSpec.swift
@@ -13,7 +13,7 @@ class PBXSourcesBuildPhaseSpec: XCTestCase {
 
     func test_init_initializesThePropertiesCorrectly() {
         XCTAssertEqual(subject.reference, "reference")
-        XCTAssertNil(subject.buildActionMask)
+        XCTAssertEqual(subject.buildActionMask, PBXBuildPhase.defaultBuildActionMask)
         XCTAssertEqual(subject.files, ["file"])
         XCTAssertNil(subject.runOnlyForDeploymentPostprocessing)
     }


### PR DESCRIPTION
### Short description 📝
With the version 1.0 of xcproj we removed the default value of the build phase `buildActionMask` property. When a build phase doesn't have that value, Xcode defaults it to `2147483647`.

Thanks, @yonaskolb for the report.

### Solution 📦
Add the default value back.

### Implementation 👩‍💻👨‍💻
- [x] Add the value back.

### GIF
![gif](https://media.giphy.com/media/l3vR5jB1OyCIbr8NG/giphy.gif)
