### PR TITLE
No default lastKnownFileType

### DIFF
--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -52,7 +52,7 @@ public class PBXFileReference: PBXObject, Hashable {
                 xcLanguageSpecificationIdentifier: String? = nil) {
         self.fileEncoding = fileEncoding
         self.explicitFileType = explicitFileType
-        self.lastKnownFileType = lastKnownFileType ?? path.flatMap { PBXFileReference.fileType(path: Path($0)) }
+        self.lastKnownFileType = lastKnownFileType
         self.name = name
         self.path = path
         self.sourceTree = sourceTree


### PR DESCRIPTION
### Short description 📝
Reverts auto calculation of `lastKnownFileType` introduced in #58.

### Solution 📦
It turns out that Xcode sets `explicitFileType` instead of `lastKnownFileType` for macOS app target automatically. So we shouldn't set default value for that.
```
        FR4799450001 /* LGTM.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LGTM.app; sourceTree = BUILT_PRODUCTS_DIR; };
```