### PR TITLE
added support for legacy octest

### DIFF
--- a/Sources/xcproj/PBXProductType.swift
+++ b/Sources/xcproj/PBXProductType.swift
@@ -20,6 +20,7 @@ public enum PBXProductType: String, Decodable {
     case messagesExtension = "com.apple.product-type.app-extension.messages"
     case stickerPack = "com.apple.product-type.app-extension.messages-sticker-pack"
     case xpcService = "com.apple.product-type.xpc-service"
+    case ocUnitTestBundle = "com.apple.product-type.bundle.ocunit-test"
     
     /// Returns the file extension for the given product type.
     public var fileExtension: String? {
@@ -42,6 +43,8 @@ public enum PBXProductType: String, Decodable {
             return ""
         case .xpcService:
             return "xpc"
+        case .ocUnitTestBundle:
+            return "octest"
         case .none:
             return nil
         }

--- a/Tests/xcprojTests/PBXProductTypeSpec.swift
+++ b/Tests/xcprojTests/PBXProductTypeSpec.swift
@@ -80,4 +80,8 @@ final class PBXProductTypeSpec: XCTestCase {
     func test_xpcService_hasTheRightValue() {
         XCTAssertEqual(PBXProductType.xpcService.rawValue, "com.apple.product-type.xpc-service")
     }
+    
+    func test_ocUnitTestBundle_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.ocUnitTestBundle.rawValue, "com.apple.product-type.bundle.ocunit-test")
+    }
 }


### PR DESCRIPTION
### Short description 📝
`productType = "com.apple.product-type.bundle.ocunit-test";` in PBXNativeTarget caused crash when loading project

### Solution 📦
`case ocUnitTestBundle = "com.apple.product-type.bundle.ocunit-test"` in PBXProductType has been added to address this issue