### PR TITLE
fix for projectReferences type

### DIFF
--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -32,7 +32,7 @@ public class PBXProject: PBXObject, Hashable {
     public var projectDirPath: String?
     
     /// Project references.
-    public var projectReferences: [Any]
+    public var projectReferences: [[String:String]]
     
     /// The relative root path of the project.
     public var projectRoot: String?
@@ -72,7 +72,7 @@ public class PBXProject: PBXObject, Hashable {
                 knownRegions: [String] = [],
                 productRefGroup: String? = nil,
                 projectDirPath: String? = nil,
-                projectReferences: [Any] = [],
+                projectReferences: [[String : String]] = [],
                 projectRoot: String? = nil,
                 targets: [String] = [],
                 attributes: [String: Any] = [:]) {

--- a/Tests/xcprojTests/PBXProjectSpec.swift
+++ b/Tests/xcprojTests/PBXProjectSpec.swift
@@ -18,7 +18,7 @@ final class PBXProjectSpec: XCTestCase {
                              knownRegions: ["region"],
                              productRefGroup: "group",
                              projectDirPath: "path",
-                             projectReferences: ["ref"],
+                             projectReferences: [["ref" : "ref"]],
                              projectRoot: "root",
                              targets: ["target"])
     }
@@ -38,7 +38,7 @@ final class PBXProjectSpec: XCTestCase {
         XCTAssertEqual(subject.knownRegions, ["region"])
         XCTAssertEqual(subject.productRefGroup, "group")
         XCTAssertEqual(subject.projectDirPath, "path")
-        XCTAssertEqual(subject.projectReferences as! [String], ["ref"])
+        XCTAssertTrue(subject.projectReferences.elementsEqual([["ref" : "ref"]], by: ==))
         XCTAssertEqual(subject.projectRoot, "root")
         XCTAssertEqual(subject.targets, ["target"])
     }
@@ -97,7 +97,7 @@ final class PBXProjectSpec: XCTestCase {
                                  knownRegions: ["region"],
                                  productRefGroup: "group",
                                  projectDirPath: "path",
-                                 projectReferences: ["ref"],
+                                 projectReferences: [["ref" : "ref"]],
                                  projectRoot: "root",
                                  targets: ["target"])
         XCTAssertEqual(subject, another)


### PR DESCRIPTION
### Short description 📝
Loading project with `projectReferences` was causing crash in init from decodable.

### Solution 📦
`projectReferences` type has been changed from `[Any]` to `[[String : String]]` to reflect the document.
