### PR TITLE
Add optional usesTabs property to PBXGroup

### DIFF
--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -16,6 +16,9 @@ public class PBXGroup: PBXObject, Hashable {
     /// Element source tree.
     public var sourceTree: PBXSourceTree?
 
+    /// Element uses tabs.
+    public var usesTabs: Int?
+
     // MARK: - Init
 
     /// Initializes the group with its attributes.
@@ -26,15 +29,18 @@ public class PBXGroup: PBXObject, Hashable {
     ///   - sourceTree: group source tree.
     ///   - name: group name.
     ///   - path: group path.
+    ///   - usesTabs: group uses tabs.
     public init(reference: String,
                 children: [String],
                 sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
-                path: String? = nil) {
+                path: String? = nil,
+                usesTabs: Int? = nil) {
         self.children = children
         self.name = name
         self.sourceTree = sourceTree
         self.path = path
+        self.usesTabs = usesTabs
         super.init(reference: reference)
     }
 
@@ -44,7 +50,8 @@ public class PBXGroup: PBXObject, Hashable {
             lhs.children == rhs.children &&
             lhs.name == rhs.name &&
             lhs.sourceTree == rhs.sourceTree &&
-            lhs.path == rhs.path
+            lhs.path == rhs.path &&
+            lhs.usesTabs == rhs.usesTabs
     }
     
     // MARK: - Decodable
@@ -54,6 +61,7 @@ public class PBXGroup: PBXObject, Hashable {
         case name
         case sourceTree
         case path
+        case usesTabs
     }
     
     public required init(from decoder: Decoder) throws {
@@ -62,6 +70,8 @@ public class PBXGroup: PBXObject, Hashable {
         self.children = (try container.decodeIfPresent(.children)) ?? []
         self.path = try container.decodeIfPresent(.path)
         self.sourceTree = try container.decodeIfPresent(.sourceTree)
+        let usesTabString: String? = try container.decodeIfPresent(.usesTabs)
+        self.usesTabs = usesTabString.flatMap(Int.init)
         try super.init(from: decoder)
     }
     
@@ -86,6 +96,9 @@ extension PBXGroup: PlistSerializable {
         }
         if let sourceTree = sourceTree {
             dictionary["sourceTree"] = sourceTree.plist()
+        }
+        if let usesTabs = usesTabs {
+            dictionary["usesTabs"] = .string(CommentedString("\(usesTabs)"))
         }
         return (key: CommentedString(self.reference,
                                                  comment: self.name ?? self.path),

--- a/Tests/xcprojTests/PBXGroupSpec.swift
+++ b/Tests/xcprojTests/PBXGroupSpec.swift
@@ -19,6 +19,7 @@ final class PBXGroupSpec: XCTestCase {
         XCTAssertEqual(subject.children, ["333"])
         XCTAssertEqual(subject.sourceTree, .group)
         XCTAssertEqual(subject.name, "name")
+        XCTAssertEqual(subject.usesTabs, nil)
     }
 
     func test_init_failsIfChildrenIsMissing() {
@@ -42,6 +43,13 @@ final class PBXGroupSpec: XCTestCase {
                                sourceTree: .group,
                                name: "name")
         XCTAssertEqual(subject, another)
+
+        let withUsesTabs = PBXGroup(reference: "ref",
+                                    children: ["333"],
+                                    sourceTree: .group,
+                                    name: "name",
+                                    usesTabs: 1)
+        XCTAssertNotEqual(subject, withUsesTabs)
     }
 
     func test_hashValue_returnsTheReferenceHashValue() {


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/141

### Short description 📝
Add `usesTabs` property to PBXGroup.

### Solution 📦
Just like in `PBXFileReference`, I added `usesTabs` to PBXGroup.

### Implementation 👩‍💻👨‍💻
- [x] Added `usesTabs` attribute
- [x] Added `usesTabs` CodingKeys
- [x] Added `usesTabs` property to initialisers
- [x] Added `usesTabs` to equality function
- [x] Added `usesTabs` to PlistSerializable
- [x] Added test
