### PR TITLE
Add correct comment for PBXHeadersBuildPhase

### DIFF
--- a/Sources/xcproj/PBXHeadersBuildPhase.swift
+++ b/Sources/xcproj/PBXHeadersBuildPhase.swift
@@ -43,7 +43,7 @@ extension PBXHeadersBuildPhase: PlistSerializable {
     func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = plistValues(proj: proj)
         dictionary["isa"] = .string(CommentedString(PBXHeadersBuildPhase.isa))
-        return (key: CommentedString(self.reference, comment: "Frameworks"), value: .dictionary(dictionary))
+        return (key: CommentedString(self.reference, comment: "Headers"), value: .dictionary(dictionary))
     }
     
 }


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/142

### Short description 📝
As reported in #142, `PBXHeadersBuildPhase` gets generated with the wrong comment.

### Solution 📦
Change comment to `Headers`.
