### PR TITLE
Change PBXBuildFile settings default to nil during decode

### DIFF
--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -38,7 +38,7 @@ public class PBXBuildFile: PBXObject, Hashable {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.fileRef = try container.decodeIfPresent(.fileRef)
-        self.settings = try container.decodeIfPresent([String: Any].self, forKey: .settings) ?? [:]
+        self.settings = try container.decodeIfPresent([String: Any].self, forKey: .settings)
         try super.init(from: decoder)
     }
 
@@ -46,9 +46,19 @@ public class PBXBuildFile: PBXObject, Hashable {
 
     public static func == (lhs: PBXBuildFile,
                            rhs: PBXBuildFile) -> Bool {
+        let settingsAreEqual: Bool = {
+            switch (lhs.settings, rhs.settings) {
+            case (.none, .none):
+                return true
+            case (.none, .some), (.some, .none):
+                return false
+            case (.some(let lhsSettings), .some(let rhsSettings)):
+                return NSDictionary(dictionary: lhsSettings).isEqual(to: rhsSettings)
+            }
+        }()
         return lhs.reference == rhs.reference &&
             lhs.fileRef == rhs.fileRef &&
-            NSDictionary(dictionary: lhs.settings ?? [:]).isEqual(to: rhs.settings ?? [:])
+            settingsAreEqual
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/137

### Short description 📝
Currently `PBXBuildFile` assigns default value of empty dictionary to `settings`. Because of this, during encoding, this empty dictionary gets written, instead of omitting it.

### Solution 📦
Remove default value

### GIF
![gif](https://media.giphy.com/media/bUOo29XM6lak8/giphy.gif)