### PR TITLE
Fix comments for build phases

### DIFF
--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -66,11 +66,13 @@ extension PBXBuildFile: PlistSerializable {
             fileName = name(fileRef: fileRef, proj: proj)
             dictionary["fileRef"] = .string(CommentedString(fileRef, comment: fileName))
         }
-        let fileType = proj.buildPhaseType(buildFileReference: reference)?.rawValue
         if let settings = settings {
             dictionary["settings"] = settings.plist()
         }
-        let comment = fileName.flatMap({ fileName -> String? in return fileType.flatMap({"\(fileName) in \($0)"})})
+        let buildPhaseName = proj.buildPhaseName(buildFileReference: reference)
+        let comment = fileName.flatMap({ fileName -> String? in
+            buildPhaseName.flatMap({"\(fileName) in \($0)"})
+        })
         return (key: CommentedString(self.reference, comment: comment),
                 value: .dictionary(dictionary))
     }

--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -58,7 +58,7 @@ public class PBXBuildPhase: PBXObject {
         }
         dictionary["files"] = .array(files.map { fileReference in
             let name = proj.fileName(buildFileReference: fileReference)
-            let type = proj.buildPhaseType(buildFileReference: fileReference)?.rawValue
+            let type = proj.buildPhaseName(buildFileReference: fileReference)
             let comment = name
                 .flatMap({ fileName -> String? in
                     if let type = type {

--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -90,7 +90,26 @@ extension PBXProj {
         }
         return nil
     }
-    
+
+    /// Returns the build phase name a file is in (mostly used for comments).
+    ///
+    /// - Parameter reference: reference of the file whose type name will be returned.
+    /// - Returns: the build phase name.
+    func buildPhaseName(buildFileReference: String) -> String? {
+        if sourcesBuildPhases.filter({$0.files.contains(buildFileReference)}).count != 0 {
+            return BuildPhase.sources.rawValue
+        } else if frameworksBuildPhases.filter({$0.files.contains(buildFileReference)}).count != 0 {
+            return BuildPhase.frameworks.rawValue
+        } else if resourcesBuildPhases.filter({$0.files.contains(buildFileReference)}).count != 0 {
+            return BuildPhase.resources.rawValue
+        } else if let copyFilesBuildPhase = copyFilesBuildPhases.filter({$0.files.contains(buildFileReference)}).first {
+            return  copyFilesBuildPhase.name ?? BuildPhase.copyFiles.rawValue
+        } else if headersBuildPhases.filter({$0.files.contains(buildFileReference)}).count != 0 {
+            return BuildPhase.headers.rawValue
+        }
+        return nil
+    }
+
 }
 
 // MARK: - PBXProj extension (Writable)


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/138 and https://github.com/xcodeswift/xcproj/issues/139

### Short description 📝
Currently phase type is used as comment for PBXBuildFile and PBXBuildPhase files.

### Solution 📦
Use build phase name for comments, if present, instead of phase type.

### GIF
![gif](https://media.giphy.com/media/3ohuAD7ixRV9utcdGM/giphy.gif)