### PR TITLE
Fix PBXTarget product reference comment

### DIFF
--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -108,7 +108,7 @@ public class PBXTarget: PBXObject, Hashable {
             dictionary["productType"] = .string(CommentedString("\"\(productType.rawValue)\""))
         }
         if let productReference = productReference {
-            let productReferenceComment = proj.fileName(buildFileReference: productReference)
+            let productReferenceComment = proj.fileName(fileReference: productReference)
             dictionary["productReference"] = .string(CommentedString(productReference, comment: productReferenceComment))
         }
         return (key: CommentedString(self.reference, comment: name),


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/143

### Short description 📝
PBXNativeTarget productReference is missing comment.

### Solution 📦
The comment was missing because the file name was searched from build files but should have been searched from file references.