### PR TITLE
Add PBXProject name to comments

### DIFF
--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -111,6 +111,21 @@ extension PBXProj {
         }
     }
 
+    /// Infers project name from Path and sets it as project name
+    ///
+    /// Project name is needed for certain comments when serialising PBXProj
+    ///
+    /// - Parameters:
+    ///   - path: path to .xcodeproj directory.
+    func updateProjectName(path: Path) {
+        guard path.parent().extension == "xcodeproj" else {
+            return
+        }
+        let projectName = path.parent().lastComponentWithoutExtension
+        let rootProject = projects.first(where: { $0.reference == rootObject })
+        rootProject?.name = projectName
+    }
+
 }
 
 // MARK: - PBXProj extension (Writable)

--- a/Sources/xcproj/XcodeProj.swift
+++ b/Sources/xcproj/XcodeProj.swift
@@ -26,6 +26,7 @@ public class XcodeProj {
         let pbxProjData = try Data(contentsOf: pbxprojPaths.first!.url)
         let plistDecoder = PropertyListDecoder()
         pbxproj = try plistDecoder.decode(PBXProj.self, from: pbxProjData)
+        pbxproj.updateProjectName(path: pbxprojPaths.first!)
         let xcworkspacePaths = path.glob("*.xcworkspace")
         if xcworkspacePaths.count == 0 {
             workspace = XCWorkspace()

--- a/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
@@ -28,6 +28,13 @@ final class XcodeProjIntegrationSpec: XCTestCase {
         XCTAssertNotNil(got)
     }
 
+    func test_init_setsCorrectProjectName() {
+        let proj = projectiOS()!.pbxproj
+        let rootObject = proj.rootObject
+        let rootProject = proj.projects.first(where: { $0.reference == rootObject })
+        XCTAssertEqual(rootProject?.name, "Project")
+    }
+
     // MARK: - Private
 
     private func fixtureWithoutWorkspaceProjectPath() -> Path {


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/144

### Short description 📝
Adds PBXProject name to comments.

### Solution 📦
As PBXProject name is determined by its filename:
- When decoding from path, use it to find project name and assign it to root project.
- When encoding to path, use the path to overwrite the project name.

### Alternatives considered
We could use regex to determine current project name:
```` swift
let prefix = "Build configuration list for PBXProject \""
let suffix = "\""

let projectName = String(data: data, encoding: .utf8).flatMap { project in
    project.range(of: "\(prefix).*\(suffix)", options: .regularExpression)
        .map({ range in
            String(project[range]
                .dropFirst(prefix.count)
                .dropLast(suffix.count)
            )
        })
}
````
This would help in situations where file name is not available, for example: when parsing from `Data`. But as `XcodeProj` does not at the moment directly support initialising with `Data`, I believe using file name approach is better.

### GIF
![gif](https://media.giphy.com/media/VKtsOAHDx1Luo/giphy.gif)
