### PR TITLE
Cache pbxobject references during project writing

### DIFF
--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -88,11 +88,9 @@ extension PBXBuildFile: PlistSerializable {
     }
 
     private func name(fileRef: String, proj: PBXProj) -> String? {
-        let fileReference = proj.fileReferences.getReference(fileRef)
-        let variantGroup = proj.variantGroups.getReference(fileRef)
-        if let fileReference = fileReference {
+        if let fileReference: PBXFileReference = proj.getCachedReference(fileRef) {
             return fileReference.name ?? fileReference.path
-        } else if let variantGroup = variantGroup {
+        } else if let variantGroup: PBXVariantGroup = proj.getCachedReference(fileRef) {
             return variantGroup.name
         }
         return nil

--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -73,7 +73,7 @@ extension PBXBuildFile: PlistSerializable {
         dictionary["isa"] = .string(CommentedString(PBXBuildFile.isa))
         var fileName: String?
         if let fileRef = fileRef {
-            fileName = name(fileRef: fileRef, proj: proj)
+            fileName = proj.fileName(fileReference: fileRef)
             dictionary["fileRef"] = .string(CommentedString(fileRef, comment: fileName))
         }
         if let settings = settings {
@@ -85,15 +85,6 @@ extension PBXBuildFile: PlistSerializable {
         })
         return (key: CommentedString(self.reference, comment: comment),
                 value: .dictionary(dictionary))
-    }
-
-    private func name(fileRef: String, proj: PBXProj) -> String? {
-        if let fileReference: PBXFileReference = proj.getCachedReference(fileRef) {
-            return fileReference.name ?? fileReference.path
-        } else if let variantGroup: PBXVariantGroup = proj.getCachedReference(fileRef) {
-            return variantGroup.name
-        }
-        return nil
     }
 
 }

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -106,11 +106,11 @@ extension PBXGroup: PlistSerializable {
     }
 
     fileprivate func name(reference: String, proj: PBXProj) -> String? {
-        if let group = proj.groups.getReference(reference) {
+        if let group: PBXGroup = proj.getCachedReference(reference) {
             return group.name ?? group.path
-        } else if let variantGroup = proj.variantGroups.getReference(reference) {
+        } else if let variantGroup: PBXVariantGroup = proj.getCachedReference(reference) {
             return variantGroup.name
-        } else if let file = proj.fileReferences.getReference(reference) {
+        } else if let file: PBXFileReference = proj.getCachedReference(reference) {
             return file.name ?? file.path
         }
         return nil

--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -5,28 +5,35 @@ import PathKit
 
 extension PBXProj {
     
-    /// Returns the file name from the build file reference.
+    /// Returns the file name from a build file reference.
     ///
-    /// - Parameter reference: file reference.
+    /// - Parameter buildFileReference: file reference.
     /// - Returns: build file name.
     func fileName(buildFileReference: String) -> String? {
-        guard let buildFile: PBXBuildFile = getCachedReference(buildFileReference), let fileRef = buildFile.fileRef else { return nil }
-        if let variantGroup: PBXVariantGroup = getCachedReference(fileRef) {
-            return variantGroup.name
-        } else {
-            return fileName(fileReference: fileRef)
-        }
+        guard let buildFile: PBXBuildFile = getCachedReference(buildFileReference), let fileReference = buildFile.fileRef else { return nil }
+        return fileName(fileReference: fileReference)
     }
-    
-    /// Returns the file name from the file reference.
+
+    /// Returns the file name from a file reference.
     ///
     /// - Parameter fileReference: file reference.
     /// - Returns: file name.
     func fileName(fileReference: String) -> String? {
-        if let fileReference: PBXFileReference = getCachedReference(fileReference) {
-            return fileReference.path.map { Path($0) }?.lastComponent ?? fileReference.name
+        if let variantGroup: PBXVariantGroup = getCachedReference(fileReference) {
+            return variantGroup.name
+        } else if let fileReference: PBXFileReference = getCachedReference(fileReference) {
+            return fileReference.name ?? fileReference.path
+        } else {
+            return nil
         }
-        return nil
+    }
+
+    /// Returns the configNamefile reference.
+    ///
+    /// - Parameter configReference: reference of the XCBuildConfiguration.
+    /// - Returns: config name.
+    func configName(configReference: String) -> String? {
+        return (getCachedReference(configReference) as? XCBuildConfiguration)?.name
     }
     
     /// Returns the build phase a file is in.

--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -10,13 +10,12 @@ extension PBXProj {
     /// - Parameter reference: file reference.
     /// - Returns: build file name.
     func fileName(buildFileReference: String) -> String? {
-        guard let fileRef = buildFiles.getReference(buildFileReference)?.fileRef else { return nil }
-        if let variantGroup = variantGroups.getReference(fileRef) {
+        guard let buildFile: PBXBuildFile = getCachedReference(buildFileReference), let fileRef = buildFile.fileRef else { return nil }
+        if let variantGroup: PBXVariantGroup = getCachedReference(fileRef) {
             return variantGroup.name
-        } else if fileReferences.contains(reference: fileRef) {
-            return self.fileName(fileReference: fileRef)
+        } else {
+            return fileName(fileReference: fileRef)
         }
-        return nil
     }
     
     /// Returns the file name from the file reference.
@@ -24,8 +23,8 @@ extension PBXProj {
     /// - Parameter fileReference: file reference.
     /// - Returns: file name.
     func fileName(fileReference: String) -> String? {
-        if let fileReference = fileReferences.getReference(fileReference) {
-            return fileReference.path.map({Path($0)})?.lastComponent ?? fileReference.name
+        if let fileReference: PBXFileReference = getCachedReference(fileReference) {
+            return fileReference.path.map { Path($0) }?.lastComponent ?? fileReference.name
         }
         return nil
     }

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -169,15 +169,6 @@ public class PBXProj: Decodable {
         self.objects = try objects.flatMap { try PBXObject.parse(reference: $0.key, dictionary: $0.value) }
     }
 
-    func fileName(from reference: String) -> String? {
-        let fileReference: PBXFileReference? = getCachedReference(reference)
-        return fileReference?.name ?? fileReference?.path
-    }
-
-    func configName(from reference: String) -> String? {
-        return (getCachedReference(reference) as? XCBuildConfiguration)?.name
-    }
-
     func getCachedReference<T: PBXObject>(_ reference: String) -> T? {
         return referenceCache[reference] as? T
     }

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -18,6 +18,8 @@ public class PBXProj: Decodable {
     /// Project root object.
     public var rootObject: String
 
+    var referenceCache: [String: PBXObject] = [:]
+
     public var buildFiles: [PBXBuildFile] = []
     public var aggregateTargets: [PBXAggregateTarget] = []
     public var containerItemProxies: [PBXContainerItemProxy] = []
@@ -168,12 +170,16 @@ public class PBXProj: Decodable {
     }
 
     func fileName(from reference: String) -> String? {
-        let fileReference = fileReferences.getReference(reference)
+        let fileReference: PBXFileReference? = getCachedReference(reference)
         return fileReference?.name ?? fileReference?.path
     }
 
     func configName(from reference: String) -> String? {
-        return self.buildConfigurations.getReference(reference)?.name
+        return (getCachedReference(reference) as? XCBuildConfiguration)?.name
+    }
+
+    func getCachedReference<T: PBXObject>(_ reference: String) -> T? {
+        return referenceCache[reference] as? T
     }
 
 }

--- a/Sources/xcproj/PBXProjEncoder.swift
+++ b/Sources/xcproj/PBXProjEncoder.swift
@@ -18,6 +18,10 @@ class PBXProjEncoder {
     var multiline: Bool = true
     
     func encode(proj: PBXProj) -> String {
+        // populate reference cache
+        proj.referenceCache.removeAll()
+        proj.objects.forEach { proj.referenceCache[$0.reference] = $0 }
+
         writeUtf8()
         writeNewLine()
         writeDictionaryStart()
@@ -58,6 +62,9 @@ class PBXProjEncoder {
                                                        comment: "Project object")))
         writeDictionaryEnd()
         writeNewLine()
+
+        // clear reference cache
+        proj.referenceCache.removeAll()
         return output
     }
     

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -190,7 +190,8 @@ extension PBXProject: PlistSerializable {
         }
         dictionary["targets"] = PlistValue.array(targets
             .map { target in
-                return .string(CommentedString(target, comment: proj.nativeTargets.getReference(target)?.name))
+                let targetName = (proj.getCachedReference(target) as? PBXTarget)?.name
+                return .string(CommentedString(target, comment: targetName))
         })
         dictionary["attributes"] = attributes.plist()
         return (key: CommentedString(self.reference,

--- a/Sources/xcproj/PBXTargetDependency.swift
+++ b/Sources/xcproj/PBXTargetDependency.swift
@@ -60,7 +60,8 @@ extension PBXTargetDependency: PlistSerializable {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(PBXTargetDependency.isa))
         if let target = target {
-            dictionary["target"] = .string(CommentedString(target, comment: proj.nativeTargets.getReference(target)?.name))
+            let targetName = (proj.getCachedReference(target) as? PBXTarget)?.name
+            dictionary["target"] = .string(CommentedString(target, comment: targetName))
 
         }
         if let targetProxy = targetProxy {

--- a/Sources/xcproj/PBXVariantGroup.swift
+++ b/Sources/xcproj/PBXVariantGroup.swift
@@ -74,7 +74,7 @@ extension PBXVariantGroup: PlistSerializable {
             dictionary["sourceTree"] = sourceTree.plist()
         }
         dictionary["children"] = .array(children
-            .map({PlistValue.string(CommentedString($0, comment: proj.fileName(from: $0)))}))
+            .map({PlistValue.string(CommentedString($0, comment: proj.fileName(fileReference: $0)))}))
         return (key: CommentedString(self.reference,
                                                  comment: name),
                 value: .dictionary(dictionary))

--- a/Sources/xcproj/XCBuildConfiguration.swift
+++ b/Sources/xcproj/XCBuildConfiguration.swift
@@ -69,7 +69,7 @@ extension XCBuildConfiguration: PlistSerializable {
         dictionary["name"] = .string(CommentedString(name))
         dictionary["buildSettings"] = buildSettings.plist()
         if let baseConfigurationReference = baseConfigurationReference {
-            let filename = proj.fileName(from: baseConfigurationReference)
+            let filename = proj.fileName(fileReference: baseConfigurationReference)
             dictionary["baseConfigurationReference"] = .string(CommentedString(baseConfigurationReference, comment: filename))
         }
         return (key: CommentedString(self.reference, comment: name), value: .dictionary(dictionary))

--- a/Sources/xcproj/XCConfigurationList.swift
+++ b/Sources/xcproj/XCConfigurationList.swift
@@ -67,7 +67,7 @@ extension XCConfigurationList: PlistSerializable {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(XCConfigurationList.isa))
         dictionary["buildConfigurations"] = .array(buildConfigurations
-            .map { .string(CommentedString($0, comment: proj.configName(from: $0)))
+            .map { .string(CommentedString($0, comment: proj.configName(configReference: $0)))
         })
         if let defaultConfigurationIsVisible = defaultConfigurationIsVisible {
             dictionary["defaultConfigurationIsVisible"] = .string(CommentedString("\(defaultConfigurationIsVisible)"))


### PR DESCRIPTION
This is an alternative to the reference changes in #136.

This doesn't change the public API and simply generates an internal cache of reference that can be looked up while writing, improving performance.
It's a temporary internal solution while we lock down the final public API for pbx objects.

At the moment it's a generic function that requires a type. This could be changed to seperate typed caches for all the required types.