### PR TITLE
Add Xcode property defaults

### DIFF
--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -6,19 +6,22 @@ public class PBXBuildPhase: PBXObject {
     /// Default build action mask.
     public static let defaultBuildActionMask: UInt = 2147483647
 
+    /// Default runOnlyForDeploymentPostprocessing value.
+    public static let defaultRunOnlyForDeploymentPostprocessing: UInt = 0
+
     /// Element build action mask.
-    public var buildActionMask: UInt?
+    public var buildActionMask: UInt
 
     /// Element files.
     public var files: [String]
 
     /// Element run only for deployment post processing value.
-    public var runOnlyForDeploymentPostprocessing: UInt?
+    public var runOnlyForDeploymentPostprocessing: UInt
 
     public init(reference: String,
                 files: [String] = [],
-                buildActionMask: UInt? = defaultBuildActionMask,
-                runOnlyForDeploymentPostprocessing: UInt? = nil) {
+                buildActionMask: UInt = defaultBuildActionMask,
+                runOnlyForDeploymentPostprocessing: UInt = defaultRunOnlyForDeploymentPostprocessing) {
         self.files = files
         self.buildActionMask = buildActionMask
         self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing
@@ -40,7 +43,7 @@ public class PBXBuildPhase: PBXObject {
         self.buildActionMask = buildActionMaskString.flatMap(UInt.init) ?? PBXBuildPhase.defaultBuildActionMask
         self.files = try container.decodeIfPresent(.files) ?? []
         let runOnlyForDeploymentPostprocessingString: String? = try container.decodeIfPresent(.runOnlyForDeploymentPostprocessing)
-        self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessingString.flatMap(UInt.init)
+        self.runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessingString.flatMap(UInt.init) ?? PBXBuildPhase.defaultRunOnlyForDeploymentPostprocessing
         try super.init(from: decoder)
     }
 
@@ -53,9 +56,7 @@ public class PBXBuildPhase: PBXObject {
 
     func plistValues(proj: PBXProj) -> [CommentedString: PlistValue] {
         var dictionary: [CommentedString: PlistValue] = [:]
-        if let buildActionMask = buildActionMask  {
-            dictionary["buildActionMask"] = .string(CommentedString("\(buildActionMask)"))
-        }
+        dictionary["buildActionMask"] = .string(CommentedString("\(buildActionMask)"))
         dictionary["files"] = .array(files.map { fileReference in
             let name = proj.fileName(buildFileReference: fileReference)
             let type = proj.buildPhaseName(buildFileReference: fileReference)
@@ -69,9 +70,7 @@ public class PBXBuildPhase: PBXObject {
                 })
             return .string(CommentedString(fileReference, comment: comment))
         })
-        if let runOnlyForDeploymentPostprocessing = runOnlyForDeploymentPostprocessing {
-            dictionary["runOnlyForDeploymentPostprocessing"] = .string(CommentedString("\(runOnlyForDeploymentPostprocessing)"))
-        }
+        dictionary["runOnlyForDeploymentPostprocessing"] = .string(CommentedString("\(runOnlyForDeploymentPostprocessing)"))
         return dictionary
     }
 }

--- a/Sources/xcproj/PBXCopyFilesBuildPhase.swift
+++ b/Sources/xcproj/PBXCopyFilesBuildPhase.swift
@@ -43,9 +43,9 @@ public class PBXCopyFilesBuildPhase: PBXBuildPhase, Hashable {
                 dstPath: String? = nil,
                 dstSubfolderSpec: SubFolder? = nil,
                 name: String? = nil,
-                buildActionMask: UInt? = nil,
+                buildActionMask: UInt = defaultBuildActionMask,
                 files: [String] = [],
-                runOnlyForDeploymentPostprocessing: UInt? = nil) {
+                runOnlyForDeploymentPostprocessing: UInt = defaultRunOnlyForDeploymentPostprocessing) {
         self.dstPath = dstPath
         self.dstSubfolderSpec = dstSubfolderSpec
         self.name = name

--- a/Sources/xcproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcproj/PBXShellScriptBuildPhase.swift
@@ -42,8 +42,8 @@ public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
                 outputPaths: [String],
                 shellPath: String = "/bin/sh",
                 shellScript: String?,
-                buildActionMask: UInt = 2147483647,
-                runOnlyForDeploymentPostprocessing: UInt = 0,
+                buildActionMask: UInt = defaultBuildActionMask,
+                runOnlyForDeploymentPostprocessing: UInt = defaultRunOnlyForDeploymentPostprocessing,
                 showEnvVarsInLog: UInt? = nil) {
         self.name = name
         self.inputPaths = inputPaths

--- a/Tests/xcprojTests/PBXSourcesBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXSourcesBuildPhaseSpec.swift
@@ -15,7 +15,7 @@ class PBXSourcesBuildPhaseSpec: XCTestCase {
         XCTAssertEqual(subject.reference, "reference")
         XCTAssertEqual(subject.buildActionMask, PBXBuildPhase.defaultBuildActionMask)
         XCTAssertEqual(subject.files, ["file"])
-        XCTAssertNil(subject.runOnlyForDeploymentPostprocessing)
+        XCTAssertEqual(subject.runOnlyForDeploymentPostprocessing, PBXBuildPhase.defaultRunOnlyForDeploymentPostprocessing)
     }
 
     func test_itHasTheCorrectIsa() {


### PR DESCRIPTION
This builds on the work of #131 and makes sure the default `buildActionMask` is actually applied in subclasses. 
It also provides defaults for a few other properties that xcode sets when you open the generated project. This fixes the diffs when generating from XcodeGen and goes most of the way to resolving #128