### PR TITLE
Add buildPhase property to PBXBuildPhase

### DIFF
--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -18,6 +18,11 @@ public class PBXBuildPhase: PBXObject {
     /// Element run only for deployment post processing value.
     public var runOnlyForDeploymentPostprocessing: UInt
 
+    /// The build phase type of the build phase
+    public var buildPhase: BuildPhase {
+        fatalError("This property must be override")
+    }
+
     public init(reference: String,
                 files: [String] = [],
                 buildActionMask: UInt = defaultBuildActionMask,

--- a/Sources/xcproj/PBXCopyFilesBuildPhase.swift
+++ b/Sources/xcproj/PBXCopyFilesBuildPhase.swift
@@ -28,6 +28,10 @@ public class PBXCopyFilesBuildPhase: PBXBuildPhase, Hashable {
     /// Copy files build phase name
     public var name: String?
 
+    public override var buildPhase: BuildPhase {
+        return .copyFiles
+    }
+
     // MARK: - Init
 
     /// Initializes the copy files build phase with its attributes.

--- a/Sources/xcproj/PBXFrameworksBuildPhase.swift
+++ b/Sources/xcproj/PBXFrameworksBuildPhase.swift
@@ -2,6 +2,10 @@ import Foundation
 
 /// This is the element for the framework link build phase.
 public class PBXFrameworksBuildPhase: PBXBuildPhase, Hashable {
+
+    public override var buildPhase: BuildPhase {
+        return .frameworks
+    }
     
     public static func == (lhs: PBXFrameworksBuildPhase,
                            rhs: PBXFrameworksBuildPhase) -> Bool {

--- a/Sources/xcproj/PBXHeadersBuildPhase.swift
+++ b/Sources/xcproj/PBXHeadersBuildPhase.swift
@@ -3,7 +3,11 @@ import PathKit
 
 /// This is the element for the framework headers build phase.
 public class PBXHeadersBuildPhase: PBXBuildPhase, Hashable {
-    
+
+    public override var buildPhase: BuildPhase {
+        return .headers
+    }
+
     public static func == (lhs: PBXHeadersBuildPhase,
                            rhs: PBXHeadersBuildPhase) -> Bool {
         return lhs.reference == rhs.reference &&

--- a/Sources/xcproj/PBXResourcesBuildPhase.swift
+++ b/Sources/xcproj/PBXResourcesBuildPhase.swift
@@ -2,6 +2,10 @@ import Foundation
 
 /// This is the element for the resources copy build phase.
 public class PBXResourcesBuildPhase: PBXBuildPhase, Hashable {
+
+    public override var buildPhase: BuildPhase {
+        return .resources
+    }
     
     public static func == (lhs: PBXResourcesBuildPhase,
                            rhs: PBXResourcesBuildPhase) -> Bool {

--- a/Sources/xcproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcproj/PBXShellScriptBuildPhase.swift
@@ -40,12 +40,12 @@ public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
     ///   - shellScript: shell script.
     ///   - buildActionMask: build action mask.
     public init(reference: String,
-                files: [String],
+                files: [String] = [],
                 name: String? = nil,
-                inputPaths: [String],
-                outputPaths: [String],
+                inputPaths: [String] = [],
+                outputPaths: [String] = [],
                 shellPath: String = "/bin/sh",
-                shellScript: String?,
+                shellScript: String? = nil,
                 buildActionMask: UInt = defaultBuildActionMask,
                 runOnlyForDeploymentPostprocessing: UInt = 0,
                 showEnvVarsInLog: UInt? = nil) {

--- a/Sources/xcproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcproj/PBXShellScriptBuildPhase.swift
@@ -23,6 +23,10 @@ public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
     /// Show environment variables in the logs.
     public var showEnvVarsInLog: UInt?
 
+    public override var buildPhase: BuildPhase {
+        return .runScript
+    }
+
     // MARK: - Init
 
     /// Initializes the shell script build phase with its attributes.

--- a/Sources/xcproj/PBXSourcesBuildPhase.swift
+++ b/Sources/xcproj/PBXSourcesBuildPhase.swift
@@ -2,7 +2,11 @@ import Foundation
 
 /// This is the element for the sources compilation build phase.
 public class PBXSourcesBuildPhase: PBXBuildPhase, Hashable {
-    
+
+    public override var buildPhase: BuildPhase {
+        return .sources
+    }
+
     // MARK: - Hashable
     
     public static func == (lhs: PBXSourcesBuildPhase,

--- a/Tests/xcprojTests/BuildPhaseSpecs.swift
+++ b/Tests/xcprojTests/BuildPhaseSpecs.swift
@@ -28,4 +28,28 @@ class BuildPhaseSpecs: XCTestCase {
         XCTAssertEqual(BuildPhase.headers.rawValue, "Headers")
     }
 
+    func test_sources_hasTheCorrectBuildPhase() {
+        XCTAssertEqual(BuildPhase.sources, PBXSourcesBuildPhase(reference: "").buildPhase)
+    }
+
+    func test_frameworks_hasTheCorrectBuildPhase() {
+        XCTAssertEqual(BuildPhase.frameworks, PBXFrameworksBuildPhase(reference: "").buildPhase)
+    }
+
+    func test_resources_hasTheCorrectBuildPhase() {
+        XCTAssertEqual(BuildPhase.resources, PBXResourcesBuildPhase(reference: "").buildPhase)
+    }
+
+    func test_copyFiles_hasTheCorrectBuildPhase() {
+        XCTAssertEqual(BuildPhase.copyFiles, PBXCopyFilesBuildPhase(reference: "").buildPhase)
+    }
+
+    func test_runStript_hasTheCorrectBuildPhase() {
+        XCTAssertEqual(BuildPhase.runScript, PBXShellScriptBuildPhase(reference: "").buildPhase)
+    }
+
+    func test_headers_hasTheCorrectBuildPhase() {
+        XCTAssertEqual(BuildPhase.headers, PBXHeadersBuildPhase(reference: "").buildPhase)
+    }
+
 }


### PR DESCRIPTION
This adds the build phase enum as a property of each PBXBuildPhase subclass This makes it easier to work with the polymorphic PBXProj.buildPhases