### PR TITLE
Fix CommentedString escaped string transformation

### DIFF
--- a/Fixtures/iOS/BuildSettings.xcodeproj/project.pbxproj
+++ b/Fixtures/iOS/BuildSettings.xcodeproj/project.pbxproj
@@ -1,0 +1,121 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXGroup section */
+		E458FCDF1FBDCCA000C52681 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E4966A361FBAFF5F00CDE63E = {
+			isa = PBXGroup;
+			children = (
+				E458FCDF1FBDCCA000C52681 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+		E4966A371FBAFF5F00CDE63E /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0920;
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = xcodeswift;
+			};
+			buildConfigurationList = E4966A3A1FBAFF5F00CDE63E /* Build configuration list for PBXProject "BuildSettings" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = E4966A361FBAFF5F00CDE63E;
+			productRefGroup = E458FCDF1FBDCCA000C52681 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+			);
+		};
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+		E4966A501FBAFF5F00CDE63E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[arch=*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				VALIDATE_PRODUCT = YES;
+				a = a;
+				a_escapedNewLine_a = "a\\na";
+				a_quoted = "\"a\"";
+				empty = "";
+				singleEscape = "\\";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E4966A3A1FBAFF5F00CDE63E /* Build configuration list for PBXProject "BuildSettings" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4966A501FBAFF5F00CDE63E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E4966A371FBAFF5F00CDE63E /* Project object */;
+}

--- a/Sources/xcproj/CommentedString.swift
+++ b/Sources/xcproj/CommentedString.swift
@@ -31,15 +31,14 @@ struct CommentedString {
         }
 
         var escaped = string
+        // escape escape
+        escaped = escaped.replacingOccurrences(of: "\\", with: "\\\\")
+        // escape quotes
+        escaped = escaped.replacingOccurrences(of: "\"", with: "\\\"")
+        // escape tab
+        escaped = escaped.replacingOccurrences(of: "\t", with: "\\t")
         // escape newlines
         escaped = escaped.replacingOccurrences(of: "\n", with: "\\n")
-
-        // escape quotes
-        var range: Range<String.Index>?
-        if escaped.isQuoted && escaped.count > 1 {
-            range = escaped.index(after: escaped.startIndex)..<escaped.index(before: escaped.endIndex)
-        }
-        escaped = escaped.replacingOccurrences(of: "\"", with: "\\\"", range: range).replacingOccurrences(of: "\\\\\"", with: "\\\"")
 
         if !escaped.isQuoted && escaped.rangeOfCharacter(from: CommentedString.invalidCharacters) != nil {
             escaped = escaped.quoted

--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -105,7 +105,7 @@ public class PBXTarget: PBXObject, Hashable {
             dictionary["productName"] = .string(CommentedString(productName))
         }
         if let productType = productType {
-            dictionary["productType"] = .string(CommentedString("\"\(productType.rawValue)\""))
+            dictionary["productType"] = .string(CommentedString(productType.rawValue))
         }
         if let productReference = productReference {
             let productReferenceComment = proj.fileName(fileReference: productReference)

--- a/Sources/xcproj/PlistValue.swift
+++ b/Sources/xcproj/PlistValue.swift
@@ -88,16 +88,6 @@ extension PlistValue: Equatable {
     
 }
 
-fileprivate func plistKey(_ string: String) -> String {
-    // swiftlint:disable next force_try legacy_constructor
-    let regex = try! NSRegularExpression(pattern: "\\[.+\\]", options: [])
-    if regex.firstMatch(in: string, options: [], range: NSMakeRange(0, string.count)) != nil {
-        return string.quoted
-    } else {
-        return string
-    }
-}
-
 // MARK: - Dictionary Extension (PlistValue)
 
 extension Dictionary where Key == String {
@@ -106,11 +96,11 @@ extension Dictionary where Key == String {
         var dictionary: [CommentedString: PlistValue] = [:]
         self.forEach { (key, value) in
             if let array = value as? [Any] {
-                dictionary[CommentedString(plistKey(key))] = array.plist()
+                dictionary[CommentedString(key)] = array.plist()
             } else if let subDictionary = value as? [String: Any] {
-                dictionary[CommentedString(plistKey(key))] = subDictionary.plist()
+                dictionary[CommentedString(key)] = subDictionary.plist()
             } else if let string = value as? CustomStringConvertible {
-                dictionary[CommentedString(plistKey(key))] = .string(CommentedString(string.description))
+                dictionary[CommentedString(key)] = .string(CommentedString(string.description))
             }
         }
         return .dictionary(dictionary)

--- a/Tests/xcprojTests/PBXProjWriterSpec.swift
+++ b/Tests/xcprojTests/PBXProjWriterSpec.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import PathKit
 
 @testable import xcproj
 
@@ -36,10 +37,12 @@ class PBXProjEncoderSpec: XCTestCase {
         let quote = "\""
         let escapedNewline = "\\n"
         let escapedQuote = "\\\""
+        let escapedEscape = "\\\\"
+        let escapedTab = "\\t"
 
         let values: [String: String] = [
             "a": "a",
-            "a".quoted: "a".quoted,
+            "a".quoted: "\(escapedQuote)a\(escapedQuote)".quoted,
             "@": "@".quoted,
             "[": "[".quoted,
             "<": "<".quoted,
@@ -49,29 +52,30 @@ class PBXProjEncoderSpec: XCTestCase {
             "$": "$".quoted,
             "{": "{".quoted,
             "}": "}".quoted,
-            "\\": "\\".quoted,
+            "\\": escapedEscape.quoted,
             "+": "+".quoted,
             "-": "-".quoted,
             "=": "=".quoted,
             ",": ",".quoted,
             " ": " ".quoted,
+            "\t": escapedTab.quoted,
             "a;": "a;".quoted,
             "a_a": "a_a",
             "a a": "a a".quoted,
             "": "".quoted,
             "a\(quote)q\(quote)a": "a\(escapedQuote)q\(escapedQuote)a".quoted,
-            "a\(quote)q\(quote)a".quoted: "a\(escapedQuote)q\(escapedQuote)a".quoted,
-            "a\(escapedQuote)a\(escapedQuote)": "a\(escapedQuote)a\(escapedQuote)".quoted,
+            "a\(quote)q\(quote)a".quoted: "\(escapedQuote)a\(escapedQuote)q\(escapedQuote)a\(escapedQuote)".quoted,
+            "a\(escapedQuote)a\(escapedQuote)": "a\(escapedEscape)\(escapedQuote)a\(escapedEscape)\(escapedQuote)".quoted,
             "a\na": "a\\na".quoted,
             "\n": escapedNewline.quoted,
             "\na": "\(escapedNewline)a".quoted,
             "a\n": "a\(escapedNewline)".quoted,
-            "a\na".quoted: "a\(escapedNewline)a".quoted,
-            "a\(escapedNewline)a": "a\(escapedNewline)a".quoted,
-            "a\(escapedNewline)a".quoted: "a\(escapedNewline)a".quoted,
+            "a\na".quoted: "\(escapedQuote)a\(escapedNewline)a\(escapedQuote)".quoted,
+            "a\(escapedNewline)a": "a\(escapedEscape)na".quoted,
+            "a\(escapedNewline)a".quoted: "\(escapedQuote)a\(escapedEscape)na\(escapedQuote)".quoted,
             "\"": escapedQuote.quoted,
-            "\"\"": "\"\"",
-            "\"\"\"\"": "\(escapedQuote)\(escapedQuote)".quoted,
+            "\"\"": "\(escapedQuote)\(escapedQuote)".quoted,
+            "".quoted.quoted: "\(escapedQuote)\(escapedQuote)\(escapedQuote)\(escapedQuote)".quoted,
             "a=\"\"": "a=\(escapedQuote)\(escapedQuote)".quoted,
         ]
 

--- a/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
 import PathKit
-import xcproj
+@testable import xcproj
 
 final class XcodeProjIntegrationSpec: XCTestCase {
 
@@ -33,6 +33,31 @@ final class XcodeProjIntegrationSpec: XCTestCase {
         let rootObject = proj.rootObject
         let rootProject = proj.projects.first(where: { $0.reference == rootObject })
         XCTAssertEqual(rootProject?.name, "Project")
+    }
+
+    func test_noChanges_encodesSameValue() throws {
+        let path = fixturesPath() + "iOS/BuildSettings.xcodeproj"
+        let rawProj: String = try (path + "project.pbxproj").read()
+
+        let proj = try XcodeProj(path: path)
+        let encoder = PBXProjEncoder()
+        let output = encoder.encode(proj: proj.pbxproj)
+
+        XCTAssertEqual(output, rawProj)
+    }
+
+    func test_aQuoted_encodesSameValue() throws {
+        let path = fixturesPath() + "iOS/BuildSettings.xcodeproj"
+        let rawProj: String = try (path + "project.pbxproj").read()
+
+        let proj = try XcodeProj(path: path)
+        let buildConfiguration = proj.pbxproj.buildConfigurations.first!
+        buildConfiguration.buildSettings["a_quoted"] = "a".quoted
+
+        let encoder = PBXProjEncoder()
+        let output = encoder.encode(proj: proj.pbxproj)
+
+        XCTAssertEqual(output, rawProj)
     }
 
     // MARK: - Private


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/145, https://github.com/xcodeswift/xcproj/issues/71

### Short description 📝
Currently, the logic and spec for transforming quotation mark is incorrect. This was witnessed by #145. This can be validated by re-saving a project with Xcode, after you have added quotation marks to build script.

### Solution 📦
Fixed quotation mark escaping. After that it was possible to use CommentedString with `PBXTarget productType` and `PlistValue key`.

Using this fix and #132, I am able to deserialise and serialise (simple new) project without generating any diff.

### GIF
![gif](https://media.giphy.com/media/102h4wsmCG2s12/giphy.gif)

(PS! It is horrible to debug quotation marks 😭)