### PR TITLE
Use productRefGroup name as CommentedString comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.5.0 - (next release)
 
+### Fixed
+- Fix `PBXProject` `productRefGroup` comment https://github.com/xcodeswift/xcproj/pull/161 by @allu22
+
 ## 1.4.0 - Take me out
 
 ### Added

--- a/Fixtures/iOS/ProjectWithoutProductsGroup.xcodeproj/project.pbxproj
+++ b/Fixtures/iOS/ProjectWithoutProductsGroup.xcodeproj/project.pbxproj
@@ -1,0 +1,62 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXGroup section */
+		E4C06A7B1FC1CA8500A9AB51 = {
+			isa = PBXGroup;
+			children = (
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXProject section */
+		E4C06A7C1FC1CA8500A9AB51 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 0920;
+				LastUpgradeCheck = 0920;
+				ORGANIZATIONNAME = xcodeswift;
+			};
+			buildConfigurationList = E4C06A7F1FC1CA8500A9AB51 /* Build configuration list for PBXProject "ProjectWithoutProductsGroup" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+			);
+			mainGroup = E4C06A7B1FC1CA8500A9AB51;
+			productRefGroup = E4C06A7B1FC1CA8500A9AB51;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+			);
+		};
+/* End PBXProject section */
+
+/* Begin XCBuildConfiguration section */
+		E4C06A941FC1CA8500A9AB51 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E4C06A7F1FC1CA8500A9AB51 /* Build configuration list for PBXProject "ProjectWithoutProductsGroup" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E4C06A941FC1CA8500A9AB51 /* Debug */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = E4C06A7C1FC1CA8500A9AB51 /* Project object */;
+}

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -177,8 +177,9 @@ extension PBXProject: PlistSerializable {
         
         dictionary["mainGroup"] = .string(CommentedString(mainGroup))
         if let productRefGroup = productRefGroup {
+            let productRefGroupComment = proj.objects.groups[productRefGroup]?.name
             dictionary["productRefGroup"] = .string(CommentedString(productRefGroup,
-                                                                    comment: "Products"))
+                                                                    comment: productRefGroupComment))
         }
         dictionary["projectDirPath"] = .string(CommentedString(projectDirPath))
         dictionary["projectRoot"] = .string(CommentedString(projectRoot))

--- a/Tests/xcprojTests/PBXProjectSpec.swift
+++ b/Tests/xcprojTests/PBXProjectSpec.swift
@@ -107,6 +107,26 @@ final class PBXProjectSpec: XCTestCase {
         XCTAssertEqual(subject.hashValue, subject.reference.hashValue)
     }
 
+    func test_productRefGroupName_isUsedAsComment() {
+        let productsGroup = PBXGroup(reference: "group",
+                 children: [],
+                 sourceTree: .group,
+                 name: "Foo")
+
+        let proj = PBXProj(objectVersion: 48,
+                rootObject: "rootObject",
+                archiveVersion: 1,
+                classes: [:],
+                objects: [productsGroup])
+
+        let plistKV = subject.plistKeyAndValue(proj: proj)
+        if case let PlistValue.dictionary(dictionary) = plistKV.value {
+            XCTAssertEqual(dictionary["productRefGroup"]?.string?.comment, "Foo")
+        } else {
+            XCTAssert(false)
+        }
+    }
+
     private func testDictionary() -> [String: Any] {
         return [
             "buildConfigurationList": "buildConfigurationList",

--- a/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
@@ -36,14 +36,19 @@ final class XcodeProjIntegrationSpec: XCTestCase {
     }
 
     func test_noChanges_encodesSameValue() throws {
-        let path = fixturesPath() + "iOS/BuildSettings.xcodeproj"
-        let rawProj: String = try (path + "project.pbxproj").read()
+        let pathsToProjectsToTest = [
+            fixturesPath() + "iOS/BuildSettings.xcodeproj",
+            fixturesPath() + "iOS/ProjectWithoutProductsGroup.xcodeproj"
+        ]
 
-        let proj = try XcodeProj(path: path)
-        let encoder = PBXProjEncoder()
-        let output = encoder.encode(proj: proj.pbxproj)
-
-        XCTAssertEqual(output, rawProj)
+        for path in pathsToProjectsToTest {
+            let rawProj: String = try (path + "project.pbxproj").read()
+            let proj = try XcodeProj(path: path)
+            let encoder = PBXProjEncoder()
+            let output = encoder.encode(proj: proj.pbxproj)
+            
+            XCTAssertEqual(output, rawProj)
+        }
     }
 
     func test_aQuoted_encodesSameValue() throws {


### PR DESCRIPTION
### Short description 📝
At the moment `productRefGroup` comment is always `Products`. It probably covers 99.99% of use cases. But the comment should actually be a name of that group.
It will cause problems when you change the name of that group or don't have dedicated products group at all (In that case it falls back to main group).

### Solution 📦
Use productRefGroup name as CommentedString comment.

### GIF
![gif](https://media.giphy.com/media/l3q2wDX4YittWNMv6/giphy.gif)
