### PR TITLE
Fix deprecation in PBXProj objects usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fix `PBXProject` `productRefGroup` comment https://github.com/xcodeswift/xcproj/pull/161 by @allu22
+- Fix deprecation warnings for `PBXProj` objects usage https://github.com/xcodeswift/xcproj/pull/162 by @rahul-malik
 
 ## 1.4.0 - Take me out
 

--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -125,7 +125,7 @@ extension PBXProj {
             return
         }
         let projectName = path.parent().lastComponentWithoutExtension
-        let rootProject = projects.first(where: { $0.reference == rootObject })
+        let rootProject = objects.projects.getReference(rootObject)
         rootProject?.name = projectName
     }
 


### PR DESCRIPTION
### Short description 📝
Fix deprecation warning after the recent performance PR. This is likely due to other commits that merged while the PR was under review. 

### Solution 📦
Migrate the access of projects to `objects.projects` and use `getReference` to get constant time read access.

### Implementation 👩‍💻👨‍💻
- [x] Migrate deprecated usage of `projects` to `objects.projects`
- [x] Use `getReference` vs `first` for finding the project

### GIF
![gif](https://media.giphy.com/media/l4HodBpDmoMA5p9bG/giphy.gif)
