### PR TITLE
Make final classes that are not extendible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.5.0 - (next release)
 
+### Added
+- Make `final` classes that are not extendible https://github.com/xcodeswift/xcproj/pull/164 by @pepibumur.
+
 ### Fixed
 - Fix `PBXProject` `productRefGroup` comment https://github.com/xcodeswift/xcproj/pull/161 by @allu22
 - Fix deprecation warnings for `PBXProj` objects usage https://github.com/xcodeswift/xcproj/pull/162 by @rahul-malik

--- a/Sources/xcproj/PBXAggregateTarget.swift
+++ b/Sources/xcproj/PBXAggregateTarget.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for a build target that aggregates several others.
-public class PBXAggregateTarget: PBXTarget {
+final public class PBXAggregateTarget: PBXTarget {
 
 }
 
@@ -12,4 +12,5 @@ extension PBXAggregateTarget: PlistSerializable {
     func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
         return plistValues(proj: proj, isa: PBXAggregateTarget.isa)
     }
+    
 }

--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element indicates a file reference that is used in a PBXBuildPhase (either as an include or resource).
-public class PBXBuildFile: PBXObject, Hashable {
+final public class PBXBuildFile: PBXObject, Hashable {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/PBXContainerItemProxy.swift
+++ b/Sources/xcproj/PBXContainerItemProxy.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element to decorate a target item.
-public class PBXContainerItemProxy: PBXObject, Hashable {
+final public class PBXContainerItemProxy: PBXObject, Hashable {
 
     public enum ProxyType: UInt, Decodable {
         case nativeTarget = 1

--- a/Sources/xcproj/PBXCopyFilesBuildPhase.swift
+++ b/Sources/xcproj/PBXCopyFilesBuildPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for the copy file build phase.
-public class PBXCopyFilesBuildPhase: PBXBuildPhase, Hashable {
+final public class PBXCopyFilesBuildPhase: PBXBuildPhase, Hashable {
 
     public enum SubFolder: UInt, Decodable {
         case absolutePath = 0

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element is an abstract parent for file and group elements.
-public class PBXFileElement: PBXObject, Hashable {
+final public class PBXFileElement: PBXObject, Hashable {
     
     // MARK: - Attributes
 

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -3,7 +3,7 @@ import PathKit
 
 ///  A PBXFileReference is used to track every external file referenced by
 ///  the project: source files, resource files, libraries, generated application files, and so on.
-public class PBXFileReference: PBXObject, Hashable {
+final public class PBXFileReference: PBXObject, Hashable {
  
     // MARK: - Attributes
     

--- a/Sources/xcproj/PBXFrameworksBuildPhase.swift
+++ b/Sources/xcproj/PBXFrameworksBuildPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for the framework link build phase.
-public class PBXFrameworksBuildPhase: PBXBuildPhase, Hashable {
+final public class PBXFrameworksBuildPhase: PBXBuildPhase, Hashable {
 
     public override var buildPhase: BuildPhase {
         return .frameworks

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class PBXGroup: PBXObject, Hashable {
+final public class PBXGroup: PBXObject, Hashable {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/PBXHeadersBuildPhase.swift
+++ b/Sources/xcproj/PBXHeadersBuildPhase.swift
@@ -2,7 +2,7 @@ import Foundation
 import PathKit
 
 /// This is the element for the framework headers build phase.
-public class PBXHeadersBuildPhase: PBXBuildPhase, Hashable {
+final public class PBXHeadersBuildPhase: PBXBuildPhase, Hashable {
 
     public override var buildPhase: BuildPhase {
         return .headers

--- a/Sources/xcproj/PBXNativeTarget.swift
+++ b/Sources/xcproj/PBXNativeTarget.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for a build target that produces a binary content (application or library).
-public class PBXNativeTarget: PBXTarget {
+final public class PBXNativeTarget: PBXTarget {
 
 }
 

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -2,7 +2,7 @@ import Foundation
 import PathKit
 
 /// Represents a .pbxproj file
-public class PBXProj: Decodable {
+final public class PBXProj: Decodable {
     public class Objects: Equatable {
         // MARK: - Properties
         public var buildFiles: ReferenceableCollection<PBXBuildFile> = [:]

--- a/Sources/xcproj/PBXProjEncoder.swift
+++ b/Sources/xcproj/PBXProjEncoder.swift
@@ -11,7 +11,7 @@ extension PlistSerializable {
 }
 
 /// Encodes your PBXProj files to String
-class PBXProjEncoder {
+final class PBXProjEncoder {
     
     var indent: UInt = 0
     var output: String = ""

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public class PBXProject: PBXObject, Hashable {
+final public class PBXProject: PBXObject, Hashable {
     
     // MARK: - Attributes
   

--- a/Sources/xcproj/PBXReferenceProxy.swift
+++ b/Sources/xcproj/PBXReferenceProxy.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A proxy for another object which might belong to another project
 /// contained in the same workspace of the document.
 /// This class is referenced by PBXTargetDependency.
-public class PBXReferenceProxy: PBXObject, Hashable {
+final public class PBXReferenceProxy: PBXObject, Hashable {
     
     // MARK: - Attributes
     

--- a/Sources/xcproj/PBXResourcesBuildPhase.swift
+++ b/Sources/xcproj/PBXResourcesBuildPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for the resources copy build phase.
-public class PBXResourcesBuildPhase: PBXBuildPhase, Hashable {
+final public class PBXResourcesBuildPhase: PBXBuildPhase, Hashable {
 
     public override var buildPhase: BuildPhase {
         return .resources

--- a/Sources/xcproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcproj/PBXShellScriptBuildPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for the shell script build phase.
-public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
+final public class PBXShellScriptBuildPhase: PBXBuildPhase, Hashable {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/PBXSourcesBuildPhase.swift
+++ b/Sources/xcproj/PBXSourcesBuildPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for the sources compilation build phase.
-public class PBXSourcesBuildPhase: PBXBuildPhase, Hashable {
+final public class PBXSourcesBuildPhase: PBXBuildPhase, Hashable {
 
     public override var buildPhase: BuildPhase {
         return .sources

--- a/Sources/xcproj/PBXTargetDependency.swift
+++ b/Sources/xcproj/PBXTargetDependency.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for referencing other targets through content proxies.
-public class PBXTargetDependency: PBXObject, Hashable {
+final public class PBXTargetDependency: PBXObject, Hashable {
     
     // MARK: - Attributes
     

--- a/Sources/xcproj/PBXVariantGroup.swift
+++ b/Sources/xcproj/PBXVariantGroup.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // This is the element for referencing localized resources.
-public class PBXVariantGroup: PBXObject, Hashable {
+final public class PBXVariantGroup: PBXObject, Hashable {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/XCBuildConfiguration.swift
+++ b/Sources/xcproj/XCBuildConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for listing build configurations.
-public class XCBuildConfiguration: PBXObject, Hashable {
+final public class XCBuildConfiguration: PBXObject, Hashable {
    
     // MARK: - Attributes
     

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -4,7 +4,7 @@ import PathKit
 public typealias XCConfigInclude = (include: Path, config: XCConfig)
 
 /// .xcconfig configuration file.
-public class XCConfig {
+final public class XCConfig {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/XCConfigurationList.swift
+++ b/Sources/xcproj/XCConfigurationList.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for listing build configurations.
-public class XCConfigurationList: PBXObject, Hashable {
+final public class XCConfigurationList: PBXObject, Hashable {
     
     // MARK: - Attributes
     

--- a/Sources/xcproj/XCScheme.swift
+++ b/Sources/xcproj/XCScheme.swift
@@ -4,11 +4,11 @@ import PathKit
 import AEXML
 
 // swiftlint:disable:next type_body_length
-public class XCScheme {
+final public class XCScheme {
 
     // MARK: - BuildableReference
 
-    public class BuildableReference {
+    final public class BuildableReference {
         public var referencedContainer: String
         public var blueprintIdentifier: String
         public var buildableName: String
@@ -27,7 +27,7 @@ public class XCScheme {
             self.blueprintName = blueprintName
         }
 
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             guard let buildableIdentifier = element.attributes["BuildableIdentifier"] else {
                 throw XCSchemeError.missing(property: "BuildableIdentifier")
             }
@@ -50,7 +50,7 @@ public class XCScheme {
             self.referencedContainer = referencedContainer
         }
 
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             return AEXMLElement(name: "BuildableReference",
                                 value: nil,
                                 attributes: ["BuildableIdentifier": buildableIdentifier,
@@ -61,7 +61,7 @@ public class XCScheme {
         }
     }
 
-    public class TestableReference {
+    final public class TestableReference {
         public var skipped: Bool
         public var buildableReference: BuildableReference
         public init(skipped: Bool,
@@ -69,11 +69,11 @@ public class XCScheme {
             self.skipped = skipped
             self.buildableReference = buildableReference
         }
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             self.skipped = element.attributes["skipped"] == "YES"
             self.buildableReference = try BuildableReference(element: element["BuildableReference"])
         }
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             let element = AEXMLElement(name: "TestableReference",
                                        value: nil,
                                        attributes: ["skipped": skipped.xmlString])
@@ -82,18 +82,18 @@ public class XCScheme {
         }
     }
 
-    public class LocationScenarioReference {
+    final public class LocationScenarioReference {
         public var identifier: String
         public var referenceType: String
         public init(identifier: String, referenceType: String) {
             self.identifier = identifier
             self.referenceType = referenceType
         }
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             self.identifier = element.attributes["identifier"]!
             self.referenceType = element.attributes["referenceType"]!
         }
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             return AEXMLElement(name: "LocationScenarioReference",
                                 value: nil,
                                 attributes: ["identifier": identifier,
@@ -101,7 +101,7 @@ public class XCScheme {
         }
     }
 
-    public class BuildableProductRunnable {
+    final public class BuildableProductRunnable {
         public var runnableDebuggingMode: String
         public var buildableReference: BuildableReference
         public init(buildableReference: BuildableReference,
@@ -109,11 +109,11 @@ public class XCScheme {
             self.buildableReference = buildableReference
             self.runnableDebuggingMode = runnableDebuggingMode
         }
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             self.runnableDebuggingMode = element.attributes["runnableDebuggingMode"] ?? "0"
             self.buildableReference = try BuildableReference(element:  element["BuildableReference"])
         }
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             let element = AEXMLElement(name: "BuildableProductRunnable",
                                        value: nil,
                                        attributes: ["runnableDebuggingMode": runnableDebuggingMode])
@@ -124,9 +124,9 @@ public class XCScheme {
 
     // MARK: - Build Action
 
-    public class BuildAction {
+    final public class BuildAction {
 
-        public class Entry {
+        final public class Entry {
 
             public enum BuildFor {
                 case running, testing, profiling, archiving, analyzing
@@ -143,7 +143,7 @@ public class XCScheme {
                 self.buildableReference = buildableReference
                 self.buildFor = buildFor
             }
-            public init(element: AEXMLElement) throws {
+            init(element: AEXMLElement) throws {
                 var buildFor: [BuildFor] = []
                 if element.attributes["buildForTesting"] == "YES" {
                     buildFor.append(.testing)
@@ -163,7 +163,7 @@ public class XCScheme {
                 self.buildFor = buildFor
                 self.buildableReference = try BuildableReference(element: element["BuildableReference"])
             }
-            public func xmlElement() -> AEXMLElement {
+            fileprivate func xmlElement() -> AEXMLElement {
                 var attributes: [String: String] = [:]
                 attributes["buildForTesting"] = buildFor.contains(.testing) ? "YES" : "NO"
                 attributes["buildForRunning"] = buildFor.contains(.running) ? "YES" : "NO"
@@ -190,7 +190,7 @@ public class XCScheme {
             self.buildImplicitDependencies = buildImplicitDependencies
         }
 
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             parallelizeBuild = element.attributes["parallelizeBuildables"]! == "YES"
             buildImplicitDependencies = element.attributes["buildImplicitDependencies"] == "YES"
             self.buildActionEntries = try element["BuildActionEntries"]["BuildActionEntry"]
@@ -198,7 +198,7 @@ public class XCScheme {
                 .map(Entry.init) ?? []
         }
 
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             let element = AEXMLElement(name: "BuildAction",
                                        value: nil,
                                        attributes: ["parallelizeBuildables": parallelizeBuild.xmlString,
@@ -218,7 +218,7 @@ public class XCScheme {
         }
     }
 
-    public class LaunchAction {
+    final public class LaunchAction {
 
         public enum Style: String {
             case auto = "0"
@@ -261,7 +261,7 @@ public class XCScheme {
             self.locationScenarioReference = locationScenarioReference
         }
 
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             guard let buildConfiguration = element.attributes["buildConfiguration"] else {
                 throw XCSchemeError.missing(property: "buildConfiguration")
             }
@@ -293,7 +293,7 @@ public class XCScheme {
                 self.locationScenarioReference = nil
             }
         }
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             let element = AEXMLElement(name: "LaunchAction",
                                        value: nil,
                                        attributes: ["buildConfiguration": buildConfiguration,
@@ -313,7 +313,7 @@ public class XCScheme {
         }
     }
 
-    public class ProfileAction {
+    final public class ProfileAction {
         public var buildableProductRunnable: BuildableProductRunnable
         public var buildConfiguration: String
         public var shouldUseLaunchSchemeArgsEnv: Bool
@@ -333,7 +333,7 @@ public class XCScheme {
             self.useCustomWorkingDirectory = useCustomWorkingDirectory
             self.debugDocumentVersioning = debugDocumentVersioning
         }
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             guard let buildConfiguration = element.attributes["buildConfiguration"] else {
                 throw XCSchemeError.missing(property: "buildConfiguration")
             }
@@ -347,7 +347,7 @@ public class XCScheme {
             self.debugDocumentVersioning = element.attributes["debugDocumentVersioning"] == "YES"
             self.buildableProductRunnable = try BuildableProductRunnable(element: element["BuildableProductRunnable"])
         }
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             let element = AEXMLElement(name: "ProfileAction",
                                        value: nil,
                                        attributes: ["buildConfiguration": buildConfiguration,
@@ -360,7 +360,7 @@ public class XCScheme {
         }
     }
 
-    public class TestAction {
+    final public class TestAction {
         public var testables: [TestableReference]
         public var buildConfiguration: String
         public var selectedDebuggerIdentifier: String
@@ -380,7 +380,7 @@ public class XCScheme {
             self.selectedLauncherIdentifier = selectedLauncherIdentifier
             self.shouldUseLaunchSchemeArgsEnv = shouldUseLaunchSchemeArgsEnv
         }
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             guard let buildConfiguration = element.attributes["buildConfiguration"] else {
                 throw XCSchemeError.missing(property: "buildConfiguration")
             }
@@ -399,7 +399,7 @@ public class XCScheme {
                 .map(TestableReference.init) ?? []
             self.macroExpansion = try BuildableReference(element: element["MacroExpansion"]["BuildableReference"])
         }
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             var attributes: [String: String] = [:]
             attributes["buildConfiguration"] = buildConfiguration
             attributes["selectedDebuggerIdentifier"] = selectedDebuggerIdentifier
@@ -416,25 +416,25 @@ public class XCScheme {
         }
     }
 
-    public class AnalyzeAction {
+    final public class AnalyzeAction {
         public var buildConfiguration: String
         public init(buildConfiguration: String) {
             self.buildConfiguration = buildConfiguration
         }
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             guard let buildConfiguration = element.attributes["buildConfiguration"] else {
                 throw XCSchemeError.missing(property: "buildConfiguration")
             }
             self.buildConfiguration = buildConfiguration
         }
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             var attributes: [String: String] = [:]
             attributes["buildConfiguration"] = buildConfiguration
             return AEXMLElement(name: "AnalyzeAction", value: nil, attributes: attributes)
         }
     }
 
-    public class ArchiveAction {
+    final public class ArchiveAction {
         public var buildConfiguration: String
         public var revealArchiveInOrganizer: Bool
         public var customArchiveName: String?
@@ -445,7 +445,7 @@ public class XCScheme {
             self.revealArchiveInOrganizer = revealArchiveInOrganizer
             self.customArchiveName = customArchiveName
         }
-        public init(element: AEXMLElement) throws {
+        init(element: AEXMLElement) throws {
             guard let buildConfiguration = element.attributes["buildConfiguration"] else {
                 throw XCSchemeError.missing(property: "buildConfiguration")
             }
@@ -456,7 +456,7 @@ public class XCScheme {
             self.revealArchiveInOrganizer = element.attributes["revealArchiveInOrganizer"] == "YES"
             self.customArchiveName = customArchiveName
         }
-        public func xmlElement() -> AEXMLElement {
+        fileprivate func xmlElement() -> AEXMLElement {
             var attributes: [String: String] = [:]
             attributes["buildConfiguration"] = buildConfiguration
             attributes["customArchiveName"] = customArchiveName

--- a/Sources/xcproj/XCSharedData.swift
+++ b/Sources/xcproj/XCSharedData.swift
@@ -1,7 +1,7 @@
 import Foundation
 import PathKit
 
-public class XCSharedData {
+final public class XCSharedData {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/XCVersionGroup.swift
+++ b/Sources/xcproj/XCVersionGroup.swift
@@ -3,7 +3,7 @@ import PathKit
 
 /// Group that contains multiple files references to the different versions of a resource.
 /// Used to contain the different versions of a xcdatamodel
-public class XCVersionGroup: PBXObject, Hashable {
+final public class XCVersionGroup: PBXObject, Hashable {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/XCWorkspace.swift
+++ b/Sources/xcproj/XCWorkspace.swift
@@ -2,7 +2,7 @@ import Foundation
 import PathKit
 
 /// Model that represents a Xcode workspace.
-public class XCWorkspace {
+final public class XCWorkspace {
 
     /// Workspace data
     public var data: XCWorkspace.Data

--- a/Sources/xcproj/XCWorkspaceData.swift
+++ b/Sources/xcproj/XCWorkspaceData.swift
@@ -5,7 +5,7 @@ import AEXML
 // MARK: - XCWorkspace model
 public extension XCWorkspace {
 
-    public class Data: Equatable, Writable {
+    final public class Data: Equatable, Writable {
 
         public enum FileRef: Hashable, ExpressibleByStringLiteral, CustomStringConvertible {
             case project(path: Path)

--- a/Sources/xcproj/XcodeProj.swift
+++ b/Sources/xcproj/XcodeProj.swift
@@ -2,7 +2,7 @@ import Foundation
 import PathKit
 
 /// Model that represents a .xcodeproj project.
-public class XcodeProj {
+final public class XcodeProj {
 
     // MARK: - Properties
 


### PR DESCRIPTION
Partially resolves https://github.com/xcodeswift/xcproj/issues/163

### Short description 📝
Apple recommends you to make final those classes that are not extendible.

### Solution 📦
Review classes and make final those that are not supposed to be extended.

### Implementation 👩‍💻👨‍💻
- [x] Add `final` keyword to non-extendible classes

### GIF
![gif](https://media.giphy.com/media/l1J9OUoOHwR5tTm3S/giphy.gif)
