### PR TITLE
Add support for enabling test code coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.5.0 - (next release)
 
 ### Added
+- Add `codeCoverageEnabled` parameter to `TestAction` https://github.com/xcodeswift/xcproj/pull/166 by @kastiglione
 - Make `final` classes that are not extendible https://github.com/xcodeswift/xcproj/pull/164 by @pepibumur.
 
 ### Fixed

--- a/Sources/xcproj/XCScheme.swift
+++ b/Sources/xcproj/XCScheme.swift
@@ -366,19 +366,22 @@ final public class XCScheme {
         public var selectedDebuggerIdentifier: String
         public var selectedLauncherIdentifier: String
         public var shouldUseLaunchSchemeArgsEnv: Bool
+        public var codeCoverageEnabled: Bool
         public var macroExpansion: BuildableReference
         public init(buildConfiguration: String,
                     macroExpansion: BuildableReference,
                     testables: [TestableReference] = [],
                     selectedDebuggerIdentifier: String = "Xcode.DebuggerFoundation.Debugger.LLDB",
                     selectedLauncherIdentifier: String = "Xcode.DebuggerFoundation.Launcher.LLDB",
-                    shouldUseLaunchSchemeArgsEnv: Bool = true) {
+                    shouldUseLaunchSchemeArgsEnv: Bool = true,
+                    codeCoverageEnabled: Bool = false) {
             self.buildConfiguration = buildConfiguration
             self.macroExpansion = macroExpansion
             self.testables = testables
             self.selectedDebuggerIdentifier = selectedDebuggerIdentifier
             self.selectedLauncherIdentifier = selectedLauncherIdentifier
             self.shouldUseLaunchSchemeArgsEnv = shouldUseLaunchSchemeArgsEnv
+            self.codeCoverageEnabled = codeCoverageEnabled
         }
         init(element: AEXMLElement) throws {
             guard let buildConfiguration = element.attributes["buildConfiguration"] else {
@@ -394,6 +397,7 @@ final public class XCScheme {
             self.selectedDebuggerIdentifier = selectedDebuggerIdentifier
             self.selectedLauncherIdentifier = selectedLauncherIdentifier
             self.shouldUseLaunchSchemeArgsEnv = element.attributes["shouldUseLaunchSchemeArgsEnv"] == "YES"
+            self.codeCoverageEnabled = element.attributes["codeCoverageEnabled"] == "YES"
             self.testables = try element["Testables"]["TestableReference"]
                 .all?
                 .map(TestableReference.init) ?? []
@@ -405,6 +409,7 @@ final public class XCScheme {
             attributes["selectedDebuggerIdentifier"] = selectedDebuggerIdentifier
             attributes["selectedLauncherIdentifier"] = selectedLauncherIdentifier
             attributes["shouldUseLaunchSchemeArgsEnv"] = shouldUseLaunchSchemeArgsEnv.xmlString
+            attributes["codeCoverageEnabled"] = codeCoverageEnabled.xmlString
             let element = AEXMLElement(name: "TestAction", value: nil, attributes: attributes)
             let testablesElement = element.addChild(name: "Testables")
             testables.forEach { (testable) in

--- a/Tests/xcprojTests/XCSchemeSpec.swift
+++ b/Tests/xcprojTests/XCSchemeSpec.swift
@@ -48,6 +48,7 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.testAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(scheme.testAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
         XCTAssertEqual(scheme.testAction?.shouldUseLaunchSchemeArgsEnv, true)
+        XCTAssertEqual(scheme.testAction?.codeCoverageEnabled, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.skipped, false)
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.buildableIdentifier, "primary")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.blueprintIdentifier, "23766C251EAA3484007A9026")


### PR DESCRIPTION
### Short description 📝

This change allows generation of schemes where `TestAction` has `codeCoverageEnabled` enabled.

### Solution 📦

Update the `TestAction` class to optionally be constructed with a `codeCoverageEnabled` value, and updated the generated XML to include the `codeCoverageEnabled` value.

### Implementation 👩‍💻👨‍💻

- [x] Added property to `codeCoverageEnabled` to `TestAction`
- [x] Updated `TestAction`'s `init` functions and also `xmlElement`
- [x] Added new assert in `XCSchemeSpec`