### PR TITLE
Add support for editing scheme command line arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Integration tests https://github.com/xcodeswift/xcproj/pull/168 by @pepibumur
 - More examples to the README https://github.com/xcodeswift/xcproj/pull/116 by @pepibumur.
+- Add adding / editing command line arguments for Launch, Test and Profile Actions in `XCScheme`. https://github.com/xcodeswift/xcproj/pull/167 by @rahul-malik
 
 ### Fixed
 - `PBXGroup` not generating the comment properly for its children https://github.com/xcodeswift/xcproj/pull/169 by @pepibumur.

--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -50,6 +50,9 @@
       </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
+      <CommandLineArguments>
+        <CommandLineArgument argument="MyTestArgument" isEnabled="YES"></CommandLineArgument>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -77,6 +80,9 @@
          identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
          referenceType = "1">
       </LocationScenarioReference>
+      <CommandLineArguments>
+        <CommandLineArgument argument="MyLaunchArgument" isEnabled="YES"></CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -94,6 +100,9 @@
             ReferencedContainer = "container:Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+        <CommandLineArgument argument="MyProfileArgument" isEnabled="NO"></CommandLineArgument>
+      </CommandLineArguments>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Sources/xcproj/XCScheme.swift
+++ b/Sources/xcproj/XCScheme.swift
@@ -138,11 +138,13 @@ final public class XCScheme {
             self.arguments = args
         }
 
-        init(element: AEXMLElement) {
-            self.arguments = element.children.map { elt in
-                guard let argName = elt.attributes["argument"],
-                      let argEnabledRaw = elt.attributes["isEnabled"] else {
-                    fatalError("Invalid Commandline Argument Element")
+        init(element: AEXMLElement) throws {
+            self.arguments = try element.children.map { elt in
+                guard let argName = elt.attributes["argument"] else {
+                    throw XCSchemeError.missing(property: "argument")
+                }
+                guard let argEnabledRaw = elt.attributes["isEnabled"] else {
+                    throw XCSchemeError.missing(property: "isEnabled")
                 }
                 return CommandLineArgument(name: argName, enabled: argEnabledRaw == "YES")
             }
@@ -332,8 +334,9 @@ final public class XCScheme {
                 self.locationScenarioReference = nil
             }
 
-            if let commandlineOptions = element.children.first(where: { $0.name == "CommandLineArguments" }) {
-                self.commandlineArguments = CommandLineArguments(element: commandlineOptions)
+            let commandlineOptions = element["CommandLineArguments"]
+            if commandlineOptions.error == nil {
+                self.commandlineArguments = try CommandLineArguments(element: commandlineOptions)
             }
         }
         fileprivate func xmlElement() -> AEXMLElement {
@@ -398,8 +401,9 @@ final public class XCScheme {
             self.useCustomWorkingDirectory = element.attributes["useCustomWorkingDirectory"] == "YES"
             self.debugDocumentVersioning = element.attributes["debugDocumentVersioning"] == "YES"
             self.buildableProductRunnable = try BuildableProductRunnable(element: element["BuildableProductRunnable"])
-            if let commandlineOptions = element.children.first(where: { $0.name == "CommandLineArguments" }) {
-                self.commandlineArguments = CommandLineArguments(element: commandlineOptions)
+            let commandlineOptions = element["CommandLineArguments"]
+            if commandlineOptions.error == nil {
+                self.commandlineArguments = try CommandLineArguments(element: commandlineOptions)
             }
         }
         fileprivate func xmlElement() -> AEXMLElement {
@@ -465,8 +469,9 @@ final public class XCScheme {
                 .map(TestableReference.init) ?? []
             self.macroExpansion = try BuildableReference(element: element["MacroExpansion"]["BuildableReference"])
 
-            if let commandlineOptions = element.children.first(where: { $0.name == "CommandLineArguments" }) {
-                self.commandlineArguments = CommandLineArguments(element: commandlineOptions)
+            let commandlineOptions = element["CommandLineArguments"]
+            if commandlineOptions.error == nil {
+                self.commandlineArguments = try CommandLineArguments(element: commandlineOptions)
             }
         }
         fileprivate func xmlElement() -> AEXMLElement {

--- a/Sources/xcproj/XCScheme.swift
+++ b/Sources/xcproj/XCScheme.swift
@@ -126,6 +126,12 @@ final public class XCScheme {
         public struct CommandLineArgument {
             public let name: String
             public let enabled: Bool
+
+            public init(name: String, enabled: Bool) {
+                self.name = name
+                self.enabled = enabled
+            }
+
             fileprivate func xmlElement() -> AEXMLElement {
                 return AEXMLElement(name: "CommandLineArgument",
                                     value: nil,

--- a/Tests/xcprojTests/XCSchemeSpec.swift
+++ b/Tests/xcprojTests/XCSchemeSpec.swift
@@ -61,12 +61,12 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.testAction?.macroExpansion.blueprintName, "iOS")
         XCTAssertEqual(scheme.testAction?.macroExpansion.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(scheme.testAction?.macroExpansion.referencedContainer, "container:Project.xcodeproj")
-        XCTAssertNotNil(scheme.testAction?.commandlineArguments)
-        if let testCLIArgs = scheme.testAction?.commandlineArguments {
-            XCTAssertTrue(testCLIArgs.arguments.count > 0)
-            XCTAssertEqual(testCLIArgs.arguments[0].name, "MyTestArgument")
-            XCTAssertTrue(testCLIArgs.arguments[0].enabled)
-        }
+
+        let testCLIArgs = XCTAssertNotNilAndUnwrap(scheme.testAction?.commandlineArguments)
+        XCTAssertTrue(testCLIArgs.arguments.count > 0)
+        XCTAssertEqual(testCLIArgs.arguments[0].name, "MyTestArgument")
+        XCTAssertTrue(testCLIArgs.arguments[0].enabled)
+
 
         // Archive action
         XCTAssertEqual(scheme.archiveAction?.buildConfiguration, "Release")
@@ -88,12 +88,11 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.buildableName, "iOS.app")
         XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.blueprintName, "iOS")
         XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.referencedContainer, "container:Project.xcodeproj")
-        XCTAssertNotNil(scheme.profileAction?.commandlineArguments)
-        if let profileCLIArgs = scheme.profileAction?.commandlineArguments {
-            XCTAssertTrue(profileCLIArgs.arguments.count > 0)
-            XCTAssertEqual(profileCLIArgs.arguments[0].name, "MyProfileArgument")
-            XCTAssertFalse(profileCLIArgs.arguments[0].enabled)
-        }
+
+        let profileCLIArgs = XCTAssertNotNilAndUnwrap(scheme.profileAction?.commandlineArguments)
+        XCTAssertTrue(profileCLIArgs.arguments.count > 0)
+        XCTAssertEqual(profileCLIArgs.arguments[0].name, "MyProfileArgument")
+        XCTAssertFalse(profileCLIArgs.arguments[0].enabled)
 
         // Launch action
         XCTAssertEqual(scheme.launchAction?.buildConfiguration, "Debug")
@@ -114,12 +113,11 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.locationScenarioReference?.identifier, "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier")
         XCTAssertEqual(scheme.launchAction?.locationScenarioReference?.referenceType, "1")
 
-        XCTAssertNotNil(scheme.launchAction?.commandlineArguments)
-        if let launchCLIArgs = scheme.launchAction?.commandlineArguments {
-            XCTAssertTrue(launchCLIArgs.arguments.count > 0)
-            XCTAssertEqual(launchCLIArgs.arguments[0].name, "MyLaunchArgument")
-            XCTAssertTrue(launchCLIArgs.arguments[0].enabled)
-        }
+        let launchCLIArgs = XCTAssertNotNilAndUnwrap(scheme.launchAction?.commandlineArguments)
+        XCTAssertTrue(launchCLIArgs.arguments.count > 0)
+        XCTAssertEqual(launchCLIArgs.arguments[0].name, "MyLaunchArgument")
+        XCTAssertTrue(launchCLIArgs.arguments[0].enabled)
+
     }
 
     private func fixturePath() -> Path {

--- a/Tests/xcprojTests/XCSchemeSpec.swift
+++ b/Tests/xcprojTests/XCSchemeSpec.swift
@@ -61,12 +61,21 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.testAction?.macroExpansion.blueprintName, "iOS")
         XCTAssertEqual(scheme.testAction?.macroExpansion.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(scheme.testAction?.macroExpansion.referencedContainer, "container:Project.xcodeproj")
+        XCTAssertNotNil(scheme.testAction?.commandlineArguments)
+        if let testCLIArgs = scheme.testAction?.commandlineArguments {
+            XCTAssertTrue(testCLIArgs.arguments.count > 0)
+            XCTAssertEqual(testCLIArgs.arguments[0].name, "MyTestArgument")
+            XCTAssertTrue(testCLIArgs.arguments[0].enabled)
+        }
+
         // Archive action
         XCTAssertEqual(scheme.archiveAction?.buildConfiguration, "Release")
         XCTAssertEqual(scheme.archiveAction?.revealArchiveInOrganizer, true)
         XCTAssertEqual(scheme.archiveAction?.customArchiveName, "TestName")
+
         // Analyze action
         XCTAssertEqual(scheme.analyzeAction?.buildConfiguration, "Debug")
+
         // Profile action
         XCTAssertEqual(scheme.profileAction?.buildConfiguration, "Release")
         XCTAssertEqual(scheme.profileAction?.shouldUseLaunchSchemeArgsEnv, true)
@@ -79,6 +88,13 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.buildableName, "iOS.app")
         XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.blueprintName, "iOS")
         XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.referencedContainer, "container:Project.xcodeproj")
+        XCTAssertNotNil(scheme.profileAction?.commandlineArguments)
+        if let profileCLIArgs = scheme.profileAction?.commandlineArguments {
+            XCTAssertTrue(profileCLIArgs.arguments.count > 0)
+            XCTAssertEqual(profileCLIArgs.arguments[0].name, "MyProfileArgument")
+            XCTAssertFalse(profileCLIArgs.arguments[0].enabled)
+        }
+
         // Launch action
         XCTAssertEqual(scheme.launchAction?.buildConfiguration, "Debug")
         XCTAssertEqual(scheme.launchAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
@@ -97,6 +113,13 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.buildableProductRunnable.buildableReference.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(scheme.launchAction?.locationScenarioReference?.identifier, "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier")
         XCTAssertEqual(scheme.launchAction?.locationScenarioReference?.referenceType, "1")
+
+        XCTAssertNotNil(scheme.launchAction?.commandlineArguments)
+        if let launchCLIArgs = scheme.launchAction?.commandlineArguments {
+            XCTAssertTrue(launchCLIArgs.arguments.count > 0)
+            XCTAssertEqual(launchCLIArgs.arguments[0].name, "MyLaunchArgument")
+            XCTAssertTrue(launchCLIArgs.arguments[0].enabled)
+        }
     }
 
     private func fixturePath() -> Path {

--- a/Tests/xcprojTests/XCTestCase+Assertions.swift
+++ b/Tests/xcprojTests/XCTestCase+Assertions.swift
@@ -5,7 +5,7 @@ extension XCTestCase {
     func XCTAssertNotNilAndUnwrap<T>(_ obj: T?, message: String = "") -> T {
         guard let unwrappedObj = obj else {
             XCTAssertNotNil(obj, message)
-            fatalError() // Unreachable since the above assertion will
+            fatalError() // Unreachable since the above assertion will fail
         }
         return unwrappedObj
     }

--- a/Tests/xcprojTests/XCTestCase+Assertions.swift
+++ b/Tests/xcprojTests/XCTestCase+Assertions.swift
@@ -1,10 +1,3 @@
-//
-//  XCTestCase+Assertions.swift
-//  xcprojTests
-//
-//  Created by Rahul Malik on 11/24/17.
-//
-
 import Foundation
 import XCTest
 

--- a/Tests/xcprojTests/XCTestCase+Assertions.swift
+++ b/Tests/xcprojTests/XCTestCase+Assertions.swift
@@ -1,0 +1,19 @@
+//
+//  XCTestCase+Assertions.swift
+//  xcprojTests
+//
+//  Created by Rahul Malik on 11/24/17.
+//
+
+import Foundation
+import XCTest
+
+extension XCTestCase {
+    func XCTAssertNotNilAndUnwrap<T>(_ obj: T?, message: String = "") -> T {
+        guard let unwrappedObj = obj else {
+            XCTAssertNotNil(obj, message)
+            fatalError() // Unreachable since the above assertion will
+        }
+        return unwrappedObj
+    }
+}

--- a/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
@@ -31,7 +31,7 @@ final class XcodeProjIntegrationSpec: XCTestCase {
     func test_init_setsCorrectProjectName() {
         let proj = projectiOS()!.pbxproj
         let rootObject = proj.rootObject
-        let rootProject = proj.projects.first(where: { $0.reference == rootObject })
+        let rootProject = proj.objects.projects.getReference(rootObject)
         XCTAssertEqual(rootProject?.name, "Project")
     }
 
@@ -56,7 +56,7 @@ final class XcodeProjIntegrationSpec: XCTestCase {
         let rawProj: String = try (path + "project.pbxproj").read()
 
         let proj = try XcodeProj(path: path)
-        let buildConfiguration = proj.pbxproj.buildConfigurations.first!
+        let buildConfiguration = proj.pbxproj.objects.buildConfigurations.first!.value
         buildConfiguration.buildSettings["a_quoted"] = "a".quoted
 
         let encoder = PBXProjEncoder()


### PR DESCRIPTION
This PR adds support for readings/writing command line arguments in scheme actions when available (Launch, Test and Profile).

Resolves https://github.com/xcodeswift/xcproj/issues/165

### Short description 📝
Depending on the project, you may wish to have command line arguments passed to scheme actions to affect their runtime behavior. This patch adds command line options to relevant

### Solution 📦
Add a new class to represent command line arguments in `XCScheme.swift`. Update the relevant actions to read / write the proper XML data

### Implementation 👩‍💻👨‍💻
- [x] Create the `CommandLineArguments` class to represent the XML element in `xcscheme` files
- [x] Update `LaunchAction`, `TestAction` and `ProfileAction` to have an optional command line arguments property (`CommandLineArguments?`)
- [x] Update `init` and `xmlElement` methods to read / write `CommandLineArguments`
- [x] Add use-case to `XCScheme` test fixture 

### GIF
![gif](https://media.giphy.com/media/9Jeseafl5ayT6/giphy.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/167)
<!-- Reviewable:end -->
