### PR TITLE
Fix the way PBXGroup generates the comment for the children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Integration tests https://github.com/xcodeswift/xcproj/pull/168 by @pepibumur
 
+### Fixed
+- `PBXGroup` not generating the comment properly for its children https://github.com/xcodeswift/xcproj/pull/169 by @pepibumur.
+
 ## 1.5.0
 
 ### Added

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -85,7 +85,7 @@ extension PBXGroup: PlistSerializable {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(PBXGroup.isa))
         dictionary["children"] = .array(children.map({ (fileReference) -> PlistValue in
-            let comment = name(reference: fileReference, proj: proj)
+            let comment = proj.fileName(fileReference: fileReference)
             return .string(CommentedString(fileReference, comment: comment))
         }))
         if let name = name {
@@ -103,17 +103,6 @@ extension PBXGroup: PlistSerializable {
         return (key: CommentedString(self.reference,
                                                  comment: self.name ?? self.path),
                 value: .dictionary(dictionary))
-    }
-
-    fileprivate func name(reference: String, proj: PBXProj) -> String? {
-        if let group: PBXGroup = proj.objects.groups.getReference(reference) {
-            return group.name ?? group.path
-        } else if let variantGroup: PBXVariantGroup = proj.objects.variantGroups.getReference(reference) {
-            return variantGroup.name
-        } else if let file: PBXFileReference = proj.objects.fileReferences.getReference(reference) {
-            return file.name ?? file.path
-        }
-        return nil
     }
 
 }

--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -24,6 +24,10 @@ extension PBXProj {
     func fileName(fileReference: String) -> String? {
         if let variantGroup: PBXVariantGroup = objects.variantGroups.getReference(fileReference) {
             return variantGroup.name
+        } else if let group: PBXGroup = objects.groups.getReference(fileReference) {
+            return group.name
+        } else if let versionGroup: XCVersionGroup = objects.versionGroups.getReference(fileReference) {
+            return versionGroup.name
         } else if let fileReference: PBXFileReference = objects.fileReferences.getReference(fileReference) {
             return fileReference.name ?? fileReference.path
         } else {


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/60

### Short description 📝
`PBXGroup` used its internal method to generate the comments for the children. This method didn't check all the types that the child could refer to.

### Solution 📦
Support `group` and `versionGroup`.

### Implementation 👩‍💻👨‍💻
- [x] Use the method form `PBXProj+Helpers`.
- [x] Support `group` and `versionGroup` in that method.

### GIF
![gif](https://media.giphy.com/media/3o6fIYJdkgrTwjXFMA/giphy.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/169)
<!-- Reviewable:end -->
