### PR TITLE
Add contract test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Integration tests https://github.com/xcodeswift/xcproj/pull/168 by @pepibumur
 - More examples to the README https://github.com/xcodeswift/xcproj/pull/116 by @pepibumur.
 - Add adding / editing command line arguments for Launch, Test and Profile Actions in `XCScheme`. https://github.com/xcodeswift/xcproj/pull/167 by @rahul-malik
+- Test the contract with XcodeGen https://github.com/xcodeswift/xcproj/pull/170 by @pepibumur
 
 ### Fixed
 - `PBXGroup` not generating the comment properly for its children https://github.com/xcodeswift/xcproj/pull/169 by @pepibumur.

--- a/Tests/xcprojIntegrationTests/XcodeGenTests.swift
+++ b/Tests/xcprojIntegrationTests/XcodeGenTests.swift
@@ -36,20 +36,16 @@ final class XcodeGenTests: XCTestCase {
                                                   encoding: .utf8)
         print("> Building XcodeGen")
         try shellOut(to: "cd \(clonePath); swift build")
+        print("> Testing XcodeGen")
+        try shellOut(to: "cd \(clonePath); swift test")
     }
     
     fileprivate func makeXcprojDependencyLocal(content: String,
                                                revision: String) throws -> String {
-        let exp = "\\.package\\(url:\\s*\\\".+xcproj.git\\\".+\\)"
-        let regex = try NSRegularExpression(pattern: exp)
-        guard let match = regex.firstMatch(in: content,
-                                           options: [],
-                                           range: NSRange.init(location: 0, length: content.count)) else {
-                                            return content
-        }
-        let output = (content as NSString).replacingCharacters(in: match.range,
-                                                               with: ".package(url: \"../..\", .revision(\"\(revision)\"))")
-        return output
+        let expression = "\\.package\\(url:\\s*\\\".+xcproj.git\\\".+\\)"
+        let replacement = ".package(url: \"../..\", .revision(\"\(revision)\"))"
+        return content.replacingOccurrences(of: expression, with: replacement, options: .regularExpression, range: nil)
     }
     
 }
+

--- a/Tests/xcprojIntegrationTests/XcodeGenTests.swift
+++ b/Tests/xcprojIntegrationTests/XcodeGenTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import XCTest
+import PathKit
+import ShellOut
+
+final class XcodeGenTests: XCTestCase {
+    
+    var tempDirectory: Path!
+    var projectDirectory: Path!
+    
+    override func setUp() {
+        super.setUp()
+        projectDirectory = (Path(#file) + "../../..").normalize()
+        tempDirectory = (projectDirectory + Path("tmp")).normalize()
+        try? tempDirectory.delete()
+        try? tempDirectory.mkpath()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        try? tempDirectory.delete()
+    }
+    
+    func test_xcodegen_builds() throws {
+        let clonePath = tempDirectory + Path("xcodegen")
+        print("> Cloning XcodeGen repository")
+        try shellOut(to: "git clone --depth=1 git@github.com:yonaskolb/XcodeGen.git \(clonePath.string)")
+        let packageSwiftPath = clonePath + Path("Package.swift")
+        let revisionCommand = "git --git-dir \(projectDirectory.string)/.git rev-list --max-count=1 HEAD"
+        let revision = try shellOut(to: revisionCommand)
+        let packageSwiftString = try String(contentsOf: packageSwiftPath.url)
+        let packageSwiftWithLocalDependency = try makeXcprojDependencyLocal(content: packageSwiftString, revision: revision)
+        print("> Updating Package.swift to use the local xcproj")
+        try packageSwiftWithLocalDependency.write(to: packageSwiftPath.url,
+                                                  atomically: true,
+                                                  encoding: .utf8)
+        print("> Building XcodeGen")
+        try shellOut(to: "cd \(clonePath); swift build")
+    }
+    
+    fileprivate func makeXcprojDependencyLocal(content: String,
+                                               revision: String) throws -> String {
+        let exp = "\\.package\\(url:\\s*\\\".+xcproj.git\\\".+\\)"
+        let regex = try NSRegularExpression(pattern: exp)
+        guard let match = regex.firstMatch(in: content,
+                                           options: [],
+                                           range: NSRange.init(location: 0, length: content.count)) else {
+                                            return content
+        }
+        let output = (content as NSString).replacingCharacters(in: match.range,
+                                                               with: ".package(url: \"../..\", .revision(\"\(revision)\"))")
+        return output
+    }
+    
+}


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/111

### Short description 📝
Changes in `xcproj` might break the integration from other projects. The purpose of this PR is to add a test that tests the contract with [XcodeGen](https://github.com/yonaskolb/XcodeGen). This test can be a reference to test contract with other libraries in the future.

### Solution 📦
Test the contract between `xcproj` and `xcodegen` cc @yonaskolb 

### Implementation 👩‍💻👨‍💻
- [x] Add a new integration test case.

### GIF
![gif](https://media.giphy.com/media/3oEhmCmDzqV12kkwdW/giphy.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/170)
<!-- Reviewable:end -->
