### PR TITLE
Add PBXLegacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.0 (next version)
 
 ### Added
+- PBXLegacyTarget support https://github.com/xcodeswift/xcproj/pull/171 by @bkase
 - Integration tests https://github.com/xcodeswift/xcproj/pull/168 by @pepibumur
 - More examples to the README https://github.com/xcodeswift/xcproj/pull/116 by @pepibumur.
 - Add adding / editing command line arguments for Launch, Test and Profile Actions in `XCScheme`. https://github.com/xcodeswift/xcproj/pull/167 by @rahul-malik

--- a/Sources/xcproj/PBXLegacyTarget.swift
+++ b/Sources/xcproj/PBXLegacyTarget.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// This is the element for a build target that according to Xcode is an "External Build System". You can use this target to run a script.
+final public class PBXLegacyTarget: PBXTarget {
+    /// Path to the build tool that is invoked (required)
+    public var buildToolPath: String?
+    
+    /// Build arguments to be passed to the build tool.
+    public var buildArgumentsString: String?
+    
+    /// Whether or not to pass Xcode build settings as environment variables down to the tool when invoked
+    public var passBuildSettingsInEnvironment: Bool
+    
+    /// The directory where the build tool will be invoked during a build
+    public var buildWorkingDirectory: String?
+    
+    public init(reference: String,
+                name: String,
+                buildToolPath: String? = nil,
+                buildArgumentsString: String? = nil,
+                passBuildSettingsInEnvironment: Bool = false,
+                buildWorkingDirectory: String? = nil,
+                buildConfigurationList: String? = nil,
+                buildPhases: [String] = [],
+                buildRules: [String] = [],
+                dependencies: [String] = [],
+                productName: String? = nil,
+                productReference: String? = nil,
+                productType: PBXProductType? = nil) {
+        self.buildToolPath = buildToolPath
+        self.buildArgumentsString = buildArgumentsString
+        self.passBuildSettingsInEnvironment = passBuildSettingsInEnvironment
+        self.buildWorkingDirectory = buildWorkingDirectory
+        super.init(reference: reference,
+                   name: name,
+                   buildConfigurationList: buildConfigurationList,
+                   buildPhases: buildPhases,
+                   buildRules: buildRules,
+                   dependencies: dependencies,
+                   productName: productName,
+                   productReference: productReference,
+                   productType: productType)
+    }
+    
+    // MARK: - Decodable
+    
+    fileprivate enum CodingKeys: String, CodingKey {
+        case buildToolPath
+        case buildArgumentsString
+        case passBuildSettingsInEnvironment
+        case buildWorkingDirectory
+    }
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.buildToolPath = try container.decodeIfPresent(.buildToolPath)
+        self.buildArgumentsString = try container.decodeIfPresent(.buildArgumentsString)
+        let passBuildSettingsInEnvironmentString: String? = try container.decodeIfPresent(.passBuildSettingsInEnvironment)
+        self.passBuildSettingsInEnvironment = passBuildSettingsInEnvironmentString.flatMap(Int.init).map { $0 == 1 } ?? false
+        self.buildWorkingDirectory = try container.decodeIfPresent(.buildWorkingDirectory)
+        try super.init(from: decoder)
+    }
+    
+    public static func == (lhs: PBXLegacyTarget,
+                           rhs: PBXLegacyTarget) -> Bool {
+        return (lhs as PBXTarget) == (rhs as PBXTarget) &&
+            lhs.buildToolPath == rhs.buildToolPath &&
+            lhs.buildArgumentsString == rhs.buildArgumentsString &&
+            lhs.passBuildSettingsInEnvironment == rhs.passBuildSettingsInEnvironment &&
+            lhs.buildWorkingDirectory == rhs.buildWorkingDirectory
+    }
+    
+    override func plistValues(proj: PBXProj, isa: String) -> (key: CommentedString, value: PlistValue) {
+        let (key, value) = super.plistValues(proj: proj, isa: PBXLegacyTarget.isa)
+        var dict: [CommentedString: PlistValue]!
+        switch value {
+        case let .dictionary(_dict):
+            dict = _dict
+            if let buildToolPath = buildToolPath {
+                dict["buildToolPath"] = PlistValue.string(CommentedString(buildToolPath))
+            }
+            if let buildArgumentsString = buildArgumentsString {
+                dict["buildArgumentsString"] =
+                    PlistValue.string(CommentedString(buildArgumentsString))
+            }
+            dict["passBuildSettingsInEnvironment"] =
+                PlistValue.string(passBuildSettingsInEnvironment ? "1" : "0")
+            if let buildWorkingDirectory = buildWorkingDirectory {
+                dict["buildWorkingDirectory"] =
+                    PlistValue.string(CommentedString(buildWorkingDirectory))
+            }
+        default:
+            fatalError("Expected super to give a dictionary")
+        }
+        return (key: key, value: .dictionary(dict))
+    }
+
+}
+
+// MARK: - PBXNativeTarget Extension (PlistSerializable)
+
+extension PBXLegacyTarget: PlistSerializable {
+    
+    func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
+        return plistValues(proj: proj, isa: PBXLegacyTarget.isa)
+    }
+    
+}

--- a/Sources/xcproj/PBXObject.swift
+++ b/Sources/xcproj/PBXObject.swift
@@ -36,6 +36,8 @@ public class PBXObject: Referenceable, Decodable {
         let data = try JSONSerialization.data(withJSONObject: mutableDictionary, options: [])
         guard let isa = dictionary["isa"] as? String else { throw PBXObjectError.missingIsa }
         switch isa {
+        case PBXLegacyTarget.isa:
+            return try decoder.decode(PBXLegacyTarget.self, from: data)
         case PBXNativeTarget.isa:
             return try decoder.decode(PBXNativeTarget.self, from: data)
         case PBXAggregateTarget.isa:

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -6,6 +6,7 @@ final public class PBXProj: Decodable {
     public class Objects: Equatable {
         // MARK: - Properties
         public var buildFiles: ReferenceableCollection<PBXBuildFile> = [:]
+        public var legacyTargets: ReferenceableCollection<PBXLegacyTarget> = [:]
         public var aggregateTargets: ReferenceableCollection<PBXAggregateTarget> = [:]
         public var containerItemProxies: ReferenceableCollection<PBXContainerItemProxy> = [:]
         public var groups: ReferenceableCollection<PBXGroup> = [:]
@@ -49,6 +50,7 @@ final public class PBXProj: Decodable {
         // MARK: - Equatable
         public static func == (lhs: Objects, rhs: Objects) -> Bool {
             return lhs.buildFiles == rhs.buildFiles &&
+                lhs.legacyTargets == rhs.legacyTargets &&
                 lhs.aggregateTargets == rhs.aggregateTargets &&
                 lhs.containerItemProxies == rhs.containerItemProxies &&
                 lhs.copyFilesBuildPhases == rhs.copyFilesBuildPhases &&
@@ -75,6 +77,8 @@ final public class PBXProj: Decodable {
             switch object {
             case let object as PBXBuildFile: buildFiles.append(object)
             case let object as PBXAggregateTarget: aggregateTargets.append(object)
+            case let object as PBXLegacyTarget:
+                legacyTargets.append(object)
             case let object as PBXContainerItemProxy: containerItemProxies.append(object)
             case let object as PBXCopyFilesBuildPhase: copyFilesBuildPhases.append(object)
             case let object as PBXGroup: groups.append(object)
@@ -99,7 +103,8 @@ final public class PBXProj: Decodable {
         public func getTarget(reference: String) -> PBXTarget? {
             let caches: [[String: PBXTarget]] = [
                 aggregateTargets,
-                nativeTargets
+                nativeTargets,
+                legacyTargets
             ]
             return caches.first { cache in cache[reference] != nil }?[reference]
         }
@@ -108,6 +113,7 @@ final public class PBXProj: Decodable {
             let caches: [[String: PBXObject]] = [
                 buildFiles,
                 aggregateTargets,
+                legacyTargets,
                 containerItemProxies,
                 groups,
                 configurationLists,

--- a/Sources/xcproj/PBXProjEncoder.swift
+++ b/Sources/xcproj/PBXProjEncoder.swift
@@ -37,6 +37,7 @@ final class PBXProjEncoder {
         write(section: "PBXGroup", proj: proj, object: proj.objects.groups)
         write(section: "PBXHeadersBuildPhase", proj: proj, object: proj.objects.headersBuildPhases)
         write(section: "PBXNativeTarget", proj: proj, object: proj.objects.nativeTargets)
+        write(section: "PBXLegacyTarget", proj: proj, object: proj.objects.legacyTargets)
         write(section: "PBXProject", proj: proj, object: proj.objects.projects)
         write(section: "PBXResourcesBuildPhase", proj: proj, object: proj.objects.resourcesBuildPhases)
         write(section: "PBXShellScriptBuildPhase", proj: proj, object: proj.objects.shellScriptBuildPhases)

--- a/Tests/xcprojTests/PBXLegacyTargetSpec.swift
+++ b/Tests/xcprojTests/PBXLegacyTargetSpec.swift
@@ -1,0 +1,43 @@
+import Foundation
+import XCTest
+@testable import xcproj
+
+final class PBXLegacyTargetSpec: XCTestCase {
+    
+    var subject: PBXLegacyTarget!
+    
+    override func setUp() {
+        super.setUp()
+        subject = PBXLegacyTarget(reference: "ref",
+                                  name: "name",
+                                  buildToolPath: "/usr/bin/true",
+                                  buildArgumentsString: "hello world",
+                                  passBuildSettingsInEnvironment: false,
+                                  buildWorkingDirectory: "/home/xcodeuser",
+                                  buildConfigurationList: "list",
+                                  buildPhases: ["phase"],
+                                  buildRules: ["rule"],
+                                  dependencies: ["dependency"],
+                                  productName: "productname",
+                                  productReference: "productreference",
+                                  productType: .application)
+    }
+    
+    func test_plistReturnsTheRightValue() throws {
+        let expected = PlistValue.dictionary([
+            "buildToolPath": "/usr/bin/true",
+            "buildArgumentsString": "hello world",
+            "passBuildSettingsInEnvironment": "0",
+            "buildWorkingDirectory": "/home/xcodeuser"
+        ]).dictionary!
+        
+        let plistDict = subject.plistValues(proj: PBXProj.testData(), isa: PBXLegacyTarget.isa).value.dictionary!
+        
+        (["buildToolPath",
+          "buildArgumentsString",
+          "passBuildSettingsInEnvironment",
+          "buildWorkingDirectory"] as [CommentedString]).forEach {
+            XCTAssertEqual(plistDict[$0]!, expected[$0]!)
+        }
+    }
+}


### PR DESCRIPTION

### Short description 📝
This is models the "External Build Tool" target type (internally called
PBXLegacyTarget in Xcode). All fields are optional (Xcode doesn't crash
if you omit them all). The build for this target will always fail if
 you omit the `buildToolPath`, however.

### Solution 📦
Since this is another specialization of PBXTarget it is a subclass of PBXTarget just like PBXNativeTarget. Unlike PBXNativeTarget, there are extra fields.

### Implementation 👩‍💻👨‍💻

The implementation followed from the other PBX objects I found lying around.

- [x] Mess around with PBXLegacyTarget until I could see something in Xcode
- [x] Let everyone know on the `#xcodeswift` channel on Slack
- [x] Implement it for real, with all the properties
- [ ] Test properly?

I tested by playing with XcodeGen, let me know how to write real tests!

### GIF
![gif](https://media.giphy.com/media/tn3kTJo4P4y1G/giphy.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/171)
<!-- Reviewable:end -->
