### PR TITLE
Fix encoded line breaks in PBXFileReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 🚀 Check out the guidelines [here](https://github.com/xcodeswift/contributors/blob/master/CHANGELOG_GUIDELINES.md)
 
 ## 1.7.0 (next version)
+- Fix encoded line breaks in PBXFileReference https://github.com/xcodeswift/xcproj/pull/177 by @yonaskolb
 
 ## 1.6.0
 

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -58,6 +58,8 @@ public class PBXFileElement: PBXObject, Hashable, PlistSerializable {
     }
     
     // MARK: - PlistSerializable
+
+    var multiline: Bool { return true }
     
     func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = [:]

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -97,7 +97,7 @@ final public class PBXFileReference: PBXFileElement {
     
     // MARK: - PlistSerializable
     
-    var multiline: Bool { return false }
+    override var multiline: Bool { return false }
     
     override func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = super.plistKeyAndValue(proj: proj).value.dictionary ?? [:]


### PR DESCRIPTION
Fixes regression in #173 
PBXFileReferences were being incorrectly encoded with line breaks which differs from the way Xcode encodes them, and was causing unnecessary diffs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/177)
<!-- Reviewable:end -->
