### PR TITLE
Add Xcode Extension product type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add breakpoint `condition` parameter by [@alexruperez](https://github.com/alexruperez).
+- Support Xcode Extension product type https://github.com/xcodeswift/xcproj/pull/190 by @briantkelley
 
 ## 1.7.0
 

--- a/Sources/xcproj/PBXProductType.swift
+++ b/Sources/xcproj/PBXProductType.swift
@@ -21,6 +21,7 @@ public enum PBXProductType: String, Decodable {
     case stickerPack = "com.apple.product-type.app-extension.messages-sticker-pack"
     case xpcService = "com.apple.product-type.xpc-service"
     case ocUnitTestBundle = "com.apple.product-type.bundle.ocunit-test"
+    case xcodeExtension = "com.apple.product-type.xcode-extension"
     
     /// Returns the file extension for the given product type.
     public var fileExtension: String? {
@@ -37,7 +38,7 @@ public enum PBXProductType: String, Decodable {
             return "bundle"
         case .unitTestBundle, .uiTestBundle:
             return "xctest"
-        case .appExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack:
+        case .appExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension:
             return "appex"
         case .commandLineTool:
             return ""

--- a/Tests/xcprojTests/PBXProductTypeSpec.swift
+++ b/Tests/xcprojTests/PBXProductTypeSpec.swift
@@ -84,4 +84,8 @@ final class PBXProductTypeSpec: XCTestCase {
     func test_ocUnitTestBundle_hasTheRightValue() {
         XCTAssertEqual(PBXProductType.ocUnitTestBundle.rawValue, "com.apple.product-type.bundle.ocunit-test")
     }
+
+    func test_xcodeExtension_hasTheRightValue() {
+        XCTAssertEqual(PBXProductType.xcodeExtension.rawValue, "com.apple.product-type.xcode-extension")
+    }
 }


### PR DESCRIPTION
As with other app extensions, the file extension is "appex" and Xcode encodes the type using the string "com.apple.product-type.xcode-extension".

### Short description 📝
xcproj was unable to open an Xcode project with an Xcode Extension target, which is easy enough to fix.

### Solution 📦
Added the reverse DNS-style identifier used by Xcode to identify this type of target to the `PBXProductType` enum, complete with extension and unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/190)
<!-- Reviewable:end -->
