### PR TITLE
Optimize PBXObject lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next version
 
 ### Fixed
-- Optimized performance of `PBXProj.getFileElement()` https://github.com/xcodeswift/xcproj/pull/191 by @kastiglione
+- Optimised performance of object lookups https://github.com/xcodeswift/xcproj/pull/191 by @kastiglione
 ### Added
 - Support more indentation options on PBXGroups https://github.com/xcodeswift/xcproj/pull/168 by @bkase.
 - Support `PBXLegacyTarget` https://github.com/xcodeswift/xcproj/pull/171 by @bkase.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+### Fixed
+- Optimized performance of `PBXProj.getFileElement()` https://github.com/xcodeswift/xcproj/pull/191 by @kastiglione
 ### Added
 - Support more indentation options on PBXGroups https://github.com/xcodeswift/xcproj/pull/168 by @bkase.
 - Support `PBXLegacyTarget` https://github.com/xcodeswift/xcproj/pull/171 by @bkase.

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -110,13 +110,10 @@ final public class PBXProj: Decodable {
         }
 
         public func getFileElement(reference: String) -> PBXFileElement? {
-            let caches: [[String: PBXFileElement]] = [
-                fileReferences,
-                groups,
-                variantGroups,
-                versionGroups,
-                ]
-            return caches.first { cache in cache[reference] != nil }?[reference]
+            return fileReferences[reference] ??
+                groups[reference] ??
+                variantGroups[reference] ??
+                versionGroups[reference]
         }
 
         public func getReference(_ reference: String) -> PBXObject? {

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -114,6 +114,10 @@ final public class PBXProj: Decodable {
         }
 
         public func getReference(_ reference: String) -> PBXObject? {
+            // The ?? chaining below is partitioned into separate statments because, with Swift 4, a single
+            // expression resulted in this compiler error:
+            //     Expression was too complex to be solved in reasonable time;
+            //     consider breaking up the expression into distinct sub-expressions
             let part1 = buildFiles[reference] ??
                 aggregateTargets[reference] ??
                 legacyTargets[reference] ??

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -114,29 +114,29 @@ final public class PBXProj: Decodable {
         }
 
         public func getReference(_ reference: String) -> PBXObject? {
-            let caches: [[String: PBXObject]] = [
-                buildFiles,
-                aggregateTargets,
-                legacyTargets,
-                containerItemProxies,
-                groups,
-                configurationLists,
-                buildConfigurations,
-                variantGroups,
-                targetDependencies,
-                nativeTargets,
-                fileReferences,
-                projects,
-                versionGroups,
-                referenceProxies,
-                copyFilesBuildPhases,
-                shellScriptBuildPhases,
-                resourcesBuildPhases,
-                frameworksBuildPhases,
-                headersBuildPhases,
-                sourcesBuildPhases
-            ]
-            return caches.first { cache in cache[reference] != nil }?[reference]
+            let part1 = buildFiles[reference] ??
+                aggregateTargets[reference] ??
+                legacyTargets[reference] ??
+                containerItemProxies[reference] ??
+                groups[reference]
+            let part2 = part1 ??
+                configurationLists[reference] ??
+                buildConfigurations[reference] ??
+                variantGroups[reference] ??
+                targetDependencies[reference] ??
+                nativeTargets[reference]
+            let part3 = part2 ??
+                fileReferences[reference] ??
+                projects[reference] ??
+                versionGroups[reference] ??
+                referenceProxies[reference] ??
+                copyFilesBuildPhases[reference]
+            return part3 ??
+                shellScriptBuildPhases[reference] ??
+                resourcesBuildPhases[reference] ??
+                frameworksBuildPhases[reference] ??
+                headersBuildPhases[reference] ??
+                sourcesBuildPhases[reference]
         }
 
         public func contains(reference: String) -> Bool {

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -114,33 +114,53 @@ final public class PBXProj: Decodable {
         }
 
         public func getReference(_ reference: String) -> PBXObject? {
-            // The ?? chaining below is partitioned into separate statments because, with Swift 4, a single
-            // expression resulted in this compiler error:
+            // This if-let expression is used because the equivalent chain of `??` separated lookups causes,
+            // with Swift 4, this compiler error:
             //     Expression was too complex to be solved in reasonable time;
             //     consider breaking up the expression into distinct sub-expressions
-            let part1 = buildFiles[reference] ??
-                aggregateTargets[reference] ??
-                legacyTargets[reference] ??
-                containerItemProxies[reference] ??
-                groups[reference]
-            let part2 = part1 ??
-                configurationLists[reference] ??
-                buildConfigurations[reference] ??
-                variantGroups[reference] ??
-                targetDependencies[reference] ??
-                nativeTargets[reference]
-            let part3 = part2 ??
-                fileReferences[reference] ??
-                projects[reference] ??
-                versionGroups[reference] ??
-                referenceProxies[reference] ??
-                copyFilesBuildPhases[reference]
-            return part3 ??
-                shellScriptBuildPhases[reference] ??
-                resourcesBuildPhases[reference] ??
-                frameworksBuildPhases[reference] ??
-                headersBuildPhases[reference] ??
-                sourcesBuildPhases[reference]
+            if let object = buildFiles[reference] {
+                return object
+            } else if let object = aggregateTargets[reference] {
+                return object
+            } else if let object = legacyTargets[reference] {
+                return object
+            } else if let object = containerItemProxies[reference] {
+                return object
+            } else if let object = groups[reference] {
+                return object
+            } else if let object = configurationLists[reference] {
+                return object
+            } else if let object = buildConfigurations[reference] {
+                return object
+            } else if let object = variantGroups[reference] {
+                return object
+            } else if let object = targetDependencies[reference] {
+                return object
+            } else if let object = nativeTargets[reference] {
+                return object
+            } else if let object = fileReferences[reference] {
+                return object
+            } else if let object = projects[reference] {
+                return object
+            } else if let object = versionGroups[reference] {
+                return object
+            } else if let object = referenceProxies[reference] {
+                return object
+            } else if let object = copyFilesBuildPhases[reference] {
+                return object
+            } else if let object = shellScriptBuildPhases[reference] {
+                return object
+            } else if let object = resourcesBuildPhases[reference] {
+                return object
+            } else if let object = frameworksBuildPhases[reference] {
+                return object
+            } else if let object = headersBuildPhases[reference] {
+                return object
+            } else if let object = sourcesBuildPhases[reference] {
+                return object
+            } else {
+                return nil
+            }
         }
 
         public func contains(reference: String) -> Bool {

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -101,12 +101,9 @@ final public class PBXProj: Decodable {
         }
 
         public func getTarget(reference: String) -> PBXTarget? {
-            let caches: [[String: PBXTarget]] = [
-                aggregateTargets,
-                nativeTargets,
-                legacyTargets
-            ]
-            return caches.first { cache in cache[reference] != nil }?[reference]
+            return aggregateTargets[reference] ??
+                nativeTargets[reference] ??
+                legacyTargets[reference]
         }
 
         public func getFileElement(reference: String) -> PBXFileElement? {


### PR DESCRIPTION
### Short description 📝

This change has the effect of, on my machine with my project, bringing XcodeGen's **runtime down by ~80%**, and **reducing total allocated memory down by 2.1gb**.

### Solution 📦

`PBXProj` uses a pattern which collects dictionaries into array in order to search for a specific key.

The change to `getFileElement()` replaces this search pattern with `??` chaining, because profiling shows this existing search pattern to be poorly optimized by swift, and thus `getFileElement()` is a large hot spot.

In particular, for project generation with XcodeGen, the project I'm working with went from 9-10s on my machine, to 1.5-2s. Total memory allocations went down from 2.6gb to 0.5gb.

In Instruments, the category `_HashableTypedNativeDictionaryStorage<String, PBXFileElement>` had a total allocation count of 61595, for a sum total of 2.13gb.  With this change, Instruments shows no such allocations.

All these allocations were wasting cpu as well. With this change, `_swift_release_` and `_swift_retain_` were reduced to 85ms each, down from 2.3s and 1.9s respectively.

The allocation was caused by a function named `_dictionaryUpCast()`, and this is presumably happening because these dictionaries, which are each typed to a specific subclass of `PBXObject`, are being added to an array of `[String: PBXObject]`.

### Implementation 👩‍💻👨‍💻

- [x] Profile XcodeGen on an internal project, read through the data to find potential optimizations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/191)
<!-- Reviewable:end -->