### PR TITLE
Better Support Loading Legacy Schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Added
 - Add breakpoint `condition` parameter by [@alexruperez](https://github.com/alexruperez).
 
+### Changed
+- **Breaking:** The `buildableProductRunnable` property on`XCScheme.LaunchAction` and `XCScheme.ProfileAction` is now optional. Similarly, `macroExpansion` on `XCScheme.TestAction` is also optional. https://github.com/xcodeswift/xcproj/pull/194 by @briantkelley
+- The `XCScheme` initialization from an XML file has been relaxed, better matching Xcode's behavior. Default values will be used if the XML file is missing the relevant element or attribute. https://github.com/xcodeswift/xcproj/pull/194 by @briantkelley
+
 ## 1.7.0
 
 ### Added

--- a/Fixtures/Schemes/MinimalInformation.xcscheme
+++ b/Fixtures/Schemes/MinimalInformation.xcscheme
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   version = "1.3">
+   <BuildAction>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "NO"
+            buildForTesting = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "651BA89E1E459798004EAFE5"
+               BuildableName = "ais.xctest"
+               BlueprintName = "ais-Tests"
+               ReferencedContainer = "container:ais.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference>
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "651BA89E1E459798004EAFE5"
+               BuildableName = "ais.xctest"
+               BlueprintName = "ais-Tests"
+               ReferencedContainer = "container:ais.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      useCustomWorkingDirectory = "NO">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "AI_TEST_MODE"
+            value = "integration"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+</Scheme>

--- a/Tests/xcprojTests/XCSchemeSpec.swift
+++ b/Tests/xcprojTests/XCSchemeSpec.swift
@@ -5,21 +5,17 @@ import xcproj
 
 final class XCSchemeIntegrationSpec: XCTestCase {
 
-    var subject: XCScheme?
+    func test_read_iosScheme() {
+        let subject = try? XCScheme(path: iosSchemePath)
 
-    override func setUp() {
-        subject = try? XCScheme(path: fixturePath())
-    }
-
-    func test_init_initializesTheSchemeCorrectly() {
         XCTAssertNotNil(subject)
         if let subject = subject {
             assert(scheme: subject)
         }
     }
 
-    func test_write() {
-        testWrite(from: fixturePath(),
+    func test_write_iosScheme() {
+        testWrite(from: iosSchemePath,
                   initModel: { try? XCScheme(path: $0) },
                   modify: { $0 },
                   assertion: { assert(scheme: $1) })
@@ -120,7 +116,7 @@ final class XCSchemeIntegrationSpec: XCTestCase {
 
     }
 
-    private func fixturePath() -> Path {
+    private var iosSchemePath: Path {
         return fixturesPath() + Path("iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme")
     }
 

--- a/Tests/xcprojTests/XCSchemeSpec.swift
+++ b/Tests/xcprojTests/XCSchemeSpec.swift
@@ -21,6 +21,22 @@ final class XCSchemeIntegrationSpec: XCTestCase {
                   assertion: { assert(scheme: $1) })
     }
 
+    func test_read_minimalScheme() {
+        let subject = try? XCScheme(path: minimalSchemePath)
+
+        XCTAssertNotNil(subject)
+        if let subject = subject {
+            assert(minimalScheme: subject)
+        }
+    }
+
+    func test_write_minimalScheme() {
+        testWrite(from: minimalSchemePath,
+                  initModel: { try? XCScheme(path: $0) },
+                  modify: { $0 },
+                  assertion: { assert(minimalScheme: $1) })
+    }
+
     // MARK: - Private
 
     private func assert(scheme: XCScheme) {
@@ -52,11 +68,11 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.blueprintName, "iOSTests")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(scheme.testAction?.testables.first?.buildableReference.referencedContainer, "container:Project.xcodeproj")
-        XCTAssertEqual(scheme.testAction?.macroExpansion.blueprintIdentifier, "23766C111EAA3484007A9026")
-        XCTAssertEqual(scheme.testAction?.macroExpansion.buildableName, "iOS.app")
-        XCTAssertEqual(scheme.testAction?.macroExpansion.blueprintName, "iOS")
-        XCTAssertEqual(scheme.testAction?.macroExpansion.referencedContainer, "container:Project.xcodeproj")
-        XCTAssertEqual(scheme.testAction?.macroExpansion.referencedContainer, "container:Project.xcodeproj")
+        XCTAssertEqual(scheme.testAction?.macroExpansion?.blueprintIdentifier, "23766C111EAA3484007A9026")
+        XCTAssertEqual(scheme.testAction?.macroExpansion?.buildableName, "iOS.app")
+        XCTAssertEqual(scheme.testAction?.macroExpansion?.blueprintName, "iOS")
+        XCTAssertEqual(scheme.testAction?.macroExpansion?.referencedContainer, "container:Project.xcodeproj")
+        XCTAssertEqual(scheme.testAction?.macroExpansion?.referencedContainer, "container:Project.xcodeproj")
 
         let testCLIArgs = XCTAssertNotNilAndUnwrap(scheme.testAction?.commandlineArguments)
         XCTAssertTrue(testCLIArgs.arguments.count > 0)
@@ -78,12 +94,12 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.profileAction?.savedToolIdentifier, "")
         XCTAssertEqual(scheme.profileAction?.useCustomWorkingDirectory, false)
         XCTAssertEqual(scheme.profileAction?.debugDocumentVersioning, true)
-        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.runnableDebuggingMode, "0")
-        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.buildableIdentifier, "primary")
-        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.blueprintIdentifier, "23766C111EAA3484007A9026")
-        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.buildableName, "iOS.app")
-        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.blueprintName, "iOS")
-        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable.buildableReference.referencedContainer, "container:Project.xcodeproj")
+        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable?.runnableDebuggingMode, "0")
+        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable?.buildableReference.buildableIdentifier, "primary")
+        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable?.buildableReference.blueprintIdentifier, "23766C111EAA3484007A9026")
+        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable?.buildableReference.buildableName, "iOS.app")
+        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable?.buildableReference.blueprintName, "iOS")
+        XCTAssertEqual(scheme.profileAction?.buildableProductRunnable?.buildableReference.referencedContainer, "container:Project.xcodeproj")
 
         let profileCLIArgs = XCTAssertNotNilAndUnwrap(scheme.profileAction?.commandlineArguments)
         XCTAssertTrue(profileCLIArgs.arguments.count > 0)
@@ -100,12 +116,12 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.debugDocumentVersioning, true)
         XCTAssertEqual(scheme.launchAction?.debugServiceExtension, "internal")
         XCTAssertEqual(scheme.launchAction?.allowLocationSimulation, true)
-        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable.runnableDebuggingMode, "0")
-        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable.buildableReference.buildableIdentifier, "primary")
-        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable.buildableReference.blueprintIdentifier, "23766C111EAA3484007A9026")
-        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable.buildableReference.buildableName, "iOS.app")
-        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable.buildableReference.blueprintName, "iOS")
-        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable.buildableReference.referencedContainer, "container:Project.xcodeproj")
+        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable?.runnableDebuggingMode, "0")
+        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable?.buildableReference.buildableIdentifier, "primary")
+        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable?.buildableReference.blueprintIdentifier, "23766C111EAA3484007A9026")
+        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable?.buildableReference.buildableName, "iOS.app")
+        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable?.buildableReference.blueprintName, "iOS")
+        XCTAssertEqual(scheme.launchAction?.buildableProductRunnable?.buildableReference.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(scheme.launchAction?.locationScenarioReference?.identifier, "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier")
         XCTAssertEqual(scheme.launchAction?.locationScenarioReference?.referenceType, "1")
 
@@ -116,8 +132,73 @@ final class XCSchemeIntegrationSpec: XCTestCase {
 
     }
 
+    private func assert(minimalScheme scheme: XCScheme) {
+        XCTAssertEqual(scheme.version, "1.3")
+        XCTAssertNil(scheme.lastUpgradeVersion)
+
+        // Build action
+        XCTAssertTrue(scheme.buildAction?.parallelizeBuild == true)
+        XCTAssertTrue(scheme.buildAction?.buildImplicitDependencies == true)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.testing) == true)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.running) == false)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.profiling) == true)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.archiving) == true)
+        XCTAssertTrue(scheme.buildAction?.buildActionEntries.first?.buildFor.contains(.analyzing) == true)
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries.first?.buildableReference.buildableIdentifier, "primary")
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries.first?.buildableReference.blueprintIdentifier, "651BA89E1E459798004EAFE5")
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries.first?.buildableReference.buildableName, "ais.xctest")
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries.first?.buildableReference.blueprintName, "ais-Tests")
+        XCTAssertEqual(scheme.buildAction?.buildActionEntries.first?.buildableReference.referencedContainer, "container:ais.xcodeproj")
+
+        // Test action
+        XCTAssertEqual(scheme.testAction?.buildConfiguration, "Debug")
+        XCTAssertEqual(scheme.testAction?.selectedDebuggerIdentifier, "Xcode.DebuggerFoundation.Debugger.LLDB")
+        XCTAssertEqual(scheme.testAction?.selectedLauncherIdentifier, "Xcode.DebuggerFoundation.Launcher.LLDB")
+        XCTAssertTrue(scheme.testAction?.shouldUseLaunchSchemeArgsEnv == true)
+        XCTAssertTrue(scheme.testAction?.codeCoverageEnabled == false)
+        XCTAssertNil(scheme.testAction?.macroExpansion)
+        XCTAssertNil(scheme.testAction?.commandlineArguments)
+
+        // Launch action
+        XCTAssertNil(scheme.launchAction?.buildableProductRunnable)
+        XCTAssertEqual(scheme.launchAction?.selectedDebuggerIdentifier, XCScheme.defaultDebugger)
+        XCTAssertEqual(scheme.launchAction?.selectedLauncherIdentifier, XCScheme.defaultLauncher)
+        XCTAssertEqual(scheme.launchAction?.buildConfiguration, "Debug")
+        XCTAssertEqual(scheme.launchAction?.launchStyle, XCScheme.LaunchAction.Style.auto)
+        XCTAssertTrue(scheme.launchAction?.useCustomWorkingDirectory == false)
+        XCTAssertTrue(scheme.launchAction?.ignoresPersistentStateOnLaunch == false)
+        XCTAssertTrue(scheme.launchAction?.debugDocumentVersioning == true)
+        XCTAssertEqual(scheme.launchAction?.debugServiceExtension, XCScheme.LaunchAction.defaultDebugServiceExtension)
+        XCTAssertTrue(scheme.launchAction?.allowLocationSimulation == true)
+        XCTAssertNil(scheme.launchAction?.locationScenarioReference)
+        XCTAssertNil(scheme.launchAction?.commandlineArguments)
+
+        // Profile action
+        XCTAssertNil(scheme.profileAction?.buildableProductRunnable)
+        XCTAssertEqual(scheme.profileAction?.buildConfiguration, "Release")
+        XCTAssertTrue(scheme.profileAction?.shouldUseLaunchSchemeArgsEnv == true)
+        XCTAssertEqual(scheme.profileAction?.savedToolIdentifier, "")
+        XCTAssertTrue(scheme.profileAction?.useCustomWorkingDirectory == false)
+        XCTAssertTrue(scheme.profileAction?.debugDocumentVersioning == true)
+        XCTAssertNil(scheme.profileAction?.commandlineArguments)
+
+        // Analzye action
+        XCTAssertEqual(scheme.analyzeAction?.buildConfiguration, "Debug")
+
+        // Archive action
+        XCTAssertEqual(scheme.archiveAction?.buildConfiguration, "Release")
+        XCTAssertTrue(scheme.archiveAction?.revealArchiveInOrganizer == true)
+        XCTAssertNil(scheme.archiveAction?.customArchiveName)
+    }
+
     private var iosSchemePath: Path {
         return fixturesPath() + Path("iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme")
+    }
+
+    private var minimalSchemePath: Path {
+        // Not strictly minimal in the sense that it specifies the least amount of information to be valid,
+        // but minimal in the sense it doesn't have most of the standard elements and attributes.
+        return fixturesPath() + Path("Schemes/MinimalInformation.xcscheme")
     }
 
 }


### PR DESCRIPTION
### Short description 📝
Xcode accepts just about any scheme file, filling the model with default values if necessary. xcproj rejected a number of schemes Xcode accepted in a codebase with 279 Xcode projects.

### Solution 📦
Update the XCScheme XML initialization to better match Xcode's behavior.

Note that the `buildableProductRunnable` property/element isn't required. It's possible to select "None" for the executable in the Scheme Editor, in which case Xcode won't generate the element.

The xcproj tests test xcodegen, which creates a circular dependency for validation. Because this change breaks the API, we have to fix up the xcodegen source files until it adopts the version of xcproj that contains this change.

### Implementation 👩‍💻👨‍💻
- [x] Add MinimalInformation.xcscheme, which is somewhat of a worse case scheme, to validate the changes to the scheme loading code
- [x] Open MinimalInformation.xcscheme in Xcode's Scheme Editor and close the sheet, which causes it to rewrite the scheme with default values.
- [x] Integrate the default values added by Xcode in to the XCScheme loading code as fallbacks for when the attribute or element doesn't exist.
- [x] Update the XCScheme integration test to test reading and writing the underspecified scheme to ensure it can be successfully loaded with the correct default values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/194)
<!-- Reviewable:end -->
