### PR TITLE
Optimization: Only escape CommentedString when necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next version
 
 ### Fixed
+- Optimised escaping of CommentedString https://github.com/xcodeswift/xcproj/pull/195 by @kastiglione
 - Optimised performance of object lookups https://github.com/xcodeswift/xcproj/pull/191 by @kastiglione
 ### Added
 - Add breakpoint `condition` parameter by [@alexruperez](https://github.com/alexruperez).

--- a/Sources/xcproj/CommentedString.swift
+++ b/Sources/xcproj/CommentedString.swift
@@ -32,13 +32,21 @@ struct CommentedString {
 
         var escaped = string
         // escape escape
-        escaped = escaped.replacingOccurrences(of: "\\", with: "\\\\")
+        if escaped.contains("\\" as Character) {
+            escaped = escaped.replacingOccurrences(of: "\\", with: "\\\\")
+        }
         // escape quotes
-        escaped = escaped.replacingOccurrences(of: "\"", with: "\\\"")
+        if escaped.contains("\"" as Character) {
+            escaped = escaped.replacingOccurrences(of: "\"", with: "\\\"")
+        }
         // escape tab
-        escaped = escaped.replacingOccurrences(of: "\t", with: "\\t")
+        if escaped.contains("\t" as Character) {
+            escaped = escaped.replacingOccurrences(of: "\t", with: "\\t")
+        }
         // escape newlines
-        escaped = escaped.replacingOccurrences(of: "\n", with: "\\n")
+        if escaped.contains("\n" as Character) {
+            escaped = escaped.replacingOccurrences(of: "\n", with: "\\n")
+        }
 
         if !escaped.isQuoted && escaped.rangeOfCharacter(from: CommentedString.invalidCharacters) != nil {
             escaped = escaped.quoted


### PR DESCRIPTION
### Short description 📝
Reduce unnecessary string allocations in `CommentedString.validString`. For the project I tested on, this reduced the total allocated memory used by XcodeGen by just under 60mb, from ~459mb to ~402mb. Instruments showed a 48% reduction in total `Swift._NSContiguousString` allocations, down from ~1.381 million to ~716k.

### Solution 📦
Every call to `replacingOccurrences()` creates a new copy of the string, even when no replacements occur. For `CommentedString.validString`, this means 4 copies of the string are made every time, even in a common case where no escaping is required. This code is called frequently and is a hotspot.

Additionally, Instruments is showing an allocation for each swift `String` bridged to objective-c. This means each avoided `replacingOccurrences()` call is also saving 2 string allocations for the pattern and replacement strings. The bridging cost is why the `contains()` checks are explicitly typed to `Character`. Without the explicit type, the `String` version of `contains()` is called.

### Implementation 👩‍💻👨‍💻

- [x] Ran Instruments with the Allocations template, then starting from the big numbers (of allocations), I followed the data trail

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/195)
<!-- Reviewable:end -->
