### PR TITLE
Add Support for Build Carbon Resources Build Phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 - Add breakpoint `condition` parameter by [@alexruperez](https://github.com/alexruperez).
 - Support Xcode Extension product type https://github.com/xcodeswift/xcproj/pull/190 by @briantkelley
+- Support for the legacy Build Carbon Resources build phase https://github.com/xcodeswift/xcproj/pull/196 by @briantkelley
 
 ## 1.7.0
 

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		BF1286225402 /* KeyedDecodingContainer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6357036901 /* KeyedDecodingContainer+Additions.swift */; };
 		BF1398928001 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2458458701 /* PBXProject.swift */; };
 		BF1398928002 /* PBXProject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2458458701 /* PBXProject.swift */; };
+		BF1618407401 /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8785334801 /* PBXRezBuildPhase.swift */; };
+		BF1618407402 /* PBXRezBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8785334801 /* PBXRezBuildPhase.swift */; };
 		BF1641641601 /* AEXML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR6447358001 /* AEXML.framework */; };
 		BF1993286801 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4384942301 /* PBXHeadersBuildPhase.swift */; };
 		BF1993286802 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4384942301 /* PBXHeadersBuildPhase.swift */; };
@@ -171,6 +173,7 @@
 		FR8483796101 /* PBXFileReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFileReference.swift; sourceTree = "<group>"; };
 		FR8599247801 /* JSONDecoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecoding.swift; sourceTree = "<group>"; };
 		FR8773023601 /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Dictionary.swift"; sourceTree = "<group>"; };
+		FR8785334801 /* PBXRezBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXRezBuildPhase.swift; sourceTree = "<group>"; };
 		FR8873340701 /* PathKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PathKit.framework; sourceTree = "<group>"; };
 		FR8873340702 /* PathKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PathKit.framework; sourceTree = "<group>"; };
 		FR8962043601 /* PBXContainerItemProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXContainerItemProxy.swift; sourceTree = "<group>"; };
@@ -271,6 +274,7 @@
 				FR2458458701 /* PBXProject.swift */,
 				FR1827232901 /* PBXReferenceProxy.swift */,
 				FR5190097701 /* PBXResourcesBuildPhase.swift */,
+				FR8785334801 /* PBXRezBuildPhase.swift */,
 				FR2187351101 /* PBXShellScriptBuildPhase.swift */,
 				FR2287573101 /* PBXSourceTree.swift */,
 				FR7045651001 /* PBXSourcesBuildPhase.swift */,
@@ -444,6 +448,7 @@
 				BF1398928001 /* PBXProject.swift in Sources */,
 				BF4498090401 /* PBXReferenceProxy.swift in Sources */,
 				BF3222900001 /* PBXResourcesBuildPhase.swift in Sources */,
+				BF1618407401 /* PBXRezBuildPhase.swift in Sources */,
 				BF5295135101 /* PBXShellScriptBuildPhase.swift in Sources */,
 				BF5505389401 /* PBXSourceTree.swift in Sources */,
 				BF4321991401 /* PBXSourcesBuildPhase.swift in Sources */,
@@ -502,6 +507,7 @@
 				BF1398928002 /* PBXProject.swift in Sources */,
 				BF4498090402 /* PBXReferenceProxy.swift in Sources */,
 				BF3222900002 /* PBXResourcesBuildPhase.swift in Sources */,
+				BF1618407402 /* PBXRezBuildPhase.swift in Sources */,
 				BF5295135102 /* PBXShellScriptBuildPhase.swift in Sources */,
 				BF5505389402 /* PBXSourceTree.swift in Sources */,
 				BF4321991402 /* PBXSourcesBuildPhase.swift in Sources */,

--- a/Sources/xcproj/BuildPhase.swift
+++ b/Sources/xcproj/BuildPhase.swift
@@ -8,6 +8,7 @@ import Foundation
 /// - copyFiles: files.
 /// - runScript: scripts.
 /// - headers: headers.
+/// - carbonResources: build legacy Carbon resources.
 public enum BuildPhase: String {
     case sources = "Sources"
     case frameworks = "Frameworks"
@@ -15,4 +16,5 @@ public enum BuildPhase: String {
     case copyFiles = "CopyFiles"
     case runScript = "Run Script"
     case headers = "Headers"
+    case carbonResources = "Rez"
 }

--- a/Sources/xcproj/PBXObject.swift
+++ b/Sources/xcproj/PBXObject.swift
@@ -78,6 +78,8 @@ public class PBXObject: Referenceable, Decodable {
             return try decoder.decode(PBXReferenceProxy.self, from: data)
         case XCVersionGroup.isa:
             return try decoder.decode(XCVersionGroup.self, from: data)
+        case PBXRezBuildPhase.isa:
+            return try decoder.decode(PBXRezBuildPhase.self, from: data)
         default:
             throw PBXObjectError.unknownElement(isa)
         }

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -27,6 +27,7 @@ final public class PBXProj: Decodable {
         public var frameworksBuildPhases: ReferenceableCollection<PBXFrameworksBuildPhase> = [:]
         public var headersBuildPhases: ReferenceableCollection<PBXHeadersBuildPhase> = [:]
         public var sourcesBuildPhases: ReferenceableCollection<PBXSourcesBuildPhase> = [:]
+        public var carbonResourcesBuildPhases: ReferenceableCollection<PBXRezBuildPhase> = [:]
 
         // MARK: - Computed Properties
         public var buildPhases: ReferenceableCollection<PBXBuildPhase> {
@@ -37,6 +38,7 @@ final public class PBXProj: Decodable {
             phases += self.resourcesBuildPhases.referenceValues as [PBXBuildPhase]
             phases += self.frameworksBuildPhases.referenceValues as [PBXBuildPhase]
             phases += self.headersBuildPhases.referenceValues as [PBXBuildPhase]
+            phases += self.carbonResourcesBuildPhases.referenceValues as [PBXBuildPhase]
             return Dictionary(references: phases)
         }
 
@@ -68,7 +70,8 @@ final public class PBXProj: Decodable {
                 lhs.fileReferences == rhs.fileReferences &&
                 lhs.projects == rhs.projects &&
                 lhs.versionGroups == rhs.versionGroups &&
-                lhs.referenceProxies == rhs.referenceProxies
+                lhs.referenceProxies == rhs.referenceProxies &&
+                lhs.carbonResourcesBuildPhases == rhs.carbonResourcesBuildPhases
         }
 
         // MARK: - Public Methods
@@ -96,6 +99,7 @@ final public class PBXProj: Decodable {
             case let object as PBXProject: projects.append(object)
             case let object as XCVersionGroup: versionGroups.append(object)
             case let object as PBXReferenceProxy: referenceProxies.append(object)
+            case let object as PBXRezBuildPhase: carbonResourcesBuildPhases.append(object)
             default: fatalError("Unhandled PBXObject type for \(object), this is likely a bug / todo")
             }
         }
@@ -157,6 +161,8 @@ final public class PBXProj: Decodable {
             } else if let object = headersBuildPhases[reference] {
                 return object
             } else if let object = sourcesBuildPhases[reference] {
+                return object
+            } else if let object = carbonResourcesBuildPhases[reference] {
                 return object
             } else {
                 return nil

--- a/Sources/xcproj/PBXProjEncoder.swift
+++ b/Sources/xcproj/PBXProjEncoder.swift
@@ -40,6 +40,7 @@ final class PBXProjEncoder {
         write(section: "PBXLegacyTarget", proj: proj, object: proj.objects.legacyTargets)
         write(section: "PBXProject", proj: proj, object: proj.objects.projects)
         write(section: "PBXResourcesBuildPhase", proj: proj, object: proj.objects.resourcesBuildPhases)
+        write(section: "PBXRezBuildPhase", proj: proj, object: proj.objects.carbonResourcesBuildPhases)
         write(section: "PBXShellScriptBuildPhase", proj: proj, object: proj.objects.shellScriptBuildPhases)
         write(section: "PBXSourcesBuildPhase", proj: proj, object: proj.objects.sourcesBuildPhases)
         write(section: "PBXTargetDependency", proj: proj, object: proj.objects.targetDependencies)

--- a/Sources/xcproj/PBXProjObjects+Helpers.swift
+++ b/Sources/xcproj/PBXProjObjects+Helpers.swift
@@ -68,6 +68,8 @@ extension PBXProj.Objects {
             return .copyFiles
         } else if headersBuildPhases.contains(where: { _, val in val.files.contains(buildFileReference)}) {
             return .headers
+        } else if carbonResourcesBuildPhases.contains(where: { _, val in val.files.contains(buildFileReference)}) {
+            return .carbonResources
         }
         return nil
     }
@@ -89,6 +91,8 @@ extension PBXProj.Objects {
             return .runScript
         } else if headersBuildPhases.contains(reference: buildPhaseReference) {
             return .headers
+        } else if carbonResourcesBuildPhases.contains(reference: buildPhaseReference) {
+            return .carbonResources
         }
         return nil
     }
@@ -110,6 +114,8 @@ extension PBXProj.Objects {
             return shellScriptBuildPhase.name ?? "ShellScript"
         } else if headersBuildPhases.contains(reference: buildPhaseReference) {
             return "Headers"
+        } else if carbonResourcesBuildPhases.contains(reference: buildPhaseReference) {
+            return "Rez"
         }
         return nil
     }

--- a/Sources/xcproj/PBXRezBuildPhase.swift
+++ b/Sources/xcproj/PBXRezBuildPhase.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// This is the element for the Build Carbon Resources build phase.
+/// These are legacy .r files from the Classic Mac OS era.
+final public class PBXRezBuildPhase: PBXBuildPhase {
+
+    public override var buildPhase: BuildPhase {
+        return .carbonResources
+    }
+
+    public static func == (lhs: PBXRezBuildPhase,
+                           rhs: PBXRezBuildPhase) -> Bool {
+        return lhs.reference == rhs.reference &&
+            lhs.buildActionMask == rhs.buildActionMask &&
+            lhs.files == rhs.files &&
+            lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing
+    }
+}
+
+// MARK: - PBXRezBuildPhase Extension (PlistSerializable)
+
+extension PBXRezBuildPhase: PlistSerializable {
+
+    func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
+        var dictionary: [CommentedString: PlistValue] = plistValues(proj: proj)
+        dictionary["isa"] = .string(CommentedString(PBXRezBuildPhase.isa))
+        return (key: CommentedString(self.reference, comment: "Rez"), value: .dictionary(dictionary))
+    }
+
+}

--- a/Tests/xcprojTests/BuildPhaseSpecs.swift
+++ b/Tests/xcprojTests/BuildPhaseSpecs.swift
@@ -28,6 +28,10 @@ class BuildPhaseSpecs: XCTestCase {
         XCTAssertEqual(BuildPhase.headers.rawValue, "Headers")
     }
 
+    func test_carbonResources_hasTheCorrectRawValue() {
+        XCTAssertEqual(BuildPhase.carbonResources.rawValue, "Rez")
+    }
+
     func test_sources_hasTheCorrectBuildPhase() {
         XCTAssertEqual(BuildPhase.sources, PBXSourcesBuildPhase(reference: "").buildPhase)
     }
@@ -50,6 +54,10 @@ class BuildPhaseSpecs: XCTestCase {
 
     func test_headers_hasTheCorrectBuildPhase() {
         XCTAssertEqual(BuildPhase.headers, PBXHeadersBuildPhase(reference: "").buildPhase)
+    }
+
+    func test_carbonResources_hasTheCorrectBuildPhase() {
+        XCTAssertEqual(BuildPhase.carbonResources, PBXRezBuildPhase(reference: "").buildPhase)
     }
 
 }

--- a/Tests/xcprojTests/PBXProjSpec.swift
+++ b/Tests/xcprojTests/PBXProjSpec.swift
@@ -54,7 +54,8 @@ final class PBXProjSpec: XCTestCase {
         subject.objects.addObject(PBXResourcesBuildPhase(reference: "ref4"))
         subject.objects.addObject(PBXFrameworksBuildPhase(reference: "ref5"))
         subject.objects.addObject(PBXHeadersBuildPhase(reference: "ref6"))
-        XCTAssertEqual(subject.objects.buildPhases.count, 6)
+        subject.objects.addObject(PBXRezBuildPhase(reference: "ref7"))
+        XCTAssertEqual(subject.objects.buildPhases.count, 7)
     }
 }
 

--- a/Tests/xcprojTests/PBXRezBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXRezBuildPhaseSpec.swift
@@ -1,0 +1,32 @@
+import Foundation
+import XCTest
+import xcproj
+
+final class PBXRezBuildPhaseSpec: XCTestCase {
+
+    var subject: PBXRezBuildPhase!
+
+    override func setUp() {
+        super.setUp()
+        subject = PBXRezBuildPhase(reference: "ref",
+                                   files: ["123"],
+                                   runOnlyForDeploymentPostprocessing: 0)
+    }
+
+    func test_init_initializesTheBuildPhaseWithTheRightValues() {
+        XCTAssertEqual(subject.reference, "ref")
+        XCTAssertEqual(subject.files, ["123"])
+        XCTAssertEqual(subject.runOnlyForDeploymentPostprocessing, 0)
+    }
+
+    func test_isa_returnsTheCorrectValue() {
+        XCTAssertEqual(PBXRezBuildPhase.isa, "PBXRezBuildPhase")
+    }
+
+    func test_equals_returnsTheCorrectValue() {
+        let another = PBXResourcesBuildPhase(reference: "ref",
+                                             files: ["123"],
+                                             runOnlyForDeploymentPostprocessing: 0)
+        XCTAssertEqual(subject, another)
+    }
+}


### PR DESCRIPTION
### Short description 📝
Some macOS apps still build legacy Carbon resources, which xcproj didn't support.

### Solution 📦
The Xcode project file models this in the same way as the abstract `PBXBuildPhase`, so implementation of this build phase is as easy as adding and wiring up a trivial subclass.

### Implementation 👩‍💻👨‍💻
- [x] Add to `BuildPhase` with the comment used in the pbxproj file
- [x] Subclass `PBXBuildPhase` with the `isa` name used in the pbxproj file
- [x] Add decoding support to `PBXObject`
- [x] Add a Rez build phase property `PBXProj.Objects`, add decoding support, update the `buildPhases` computed property, and update the equality operator.
- [x] Add encoding support by updating `PBXProjEncoder` and `PBXProjObjects+Helpers.swift`
- [x] Add and update unit tests
- [x] Verify a roundtrip of an .xcodeproj file through xcproj yields the `PBXRezBuildPhase` in the same location in the project file with the same information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/196)
<!-- Reviewable:end -->
