### PR TITLE
Allow custom Source Tree Specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Optimised performance of object lookups https://github.com/xcodeswift/xcproj/pull/191 by @kastiglione
+- **Breaking:** `PBXSourceTree` no longer has raw values and gained an assoicated value case to support custom locations https://github.com/xcodeswift/xcproj/pull/198 by @briantkelley
 ### Added
 - Add breakpoint `condition` parameter by [@alexruperez](https://github.com/alexruperez).
 

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -51,7 +51,7 @@ public class PBXFileElement: PBXObject, Hashable, PlistSerializable {
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.sourceTree = try container.decodeIfPresent(.sourceTree)
+        self.sourceTree = try container.decodeIfPresent(String.self, forKey: .sourceTree).map { PBXSourceTree(value: $0) }
         self.name = try container.decodeIfPresent(.name)
         self.path = try container.decodeIfPresent(.path)
         try super.init(from: decoder)

--- a/Sources/xcproj/PBXSourceTree.swift
+++ b/Sources/xcproj/PBXSourceTree.swift
@@ -2,14 +2,96 @@ import Foundation
 
 /// Specifies source trees for files
 /// Corresponds to the "Location" dropdown in Xcode's File Inspector
-public enum PBXSourceTree: String, Hashable, Decodable {
-    case none = ""
-    case absolute = "<absolute>"
-    case group = "<group>"
-    case sourceRoot = "SOURCE_ROOT"
-    case buildProductsDir = "BUILT_PRODUCTS_DIR"
-    case sdkRoot = "SDKROOT"
-    case developerDir = "DEVELOPER_DIR"
+public enum PBXSourceTree: CustomStringConvertible, Equatable, Decodable {
+
+    case none
+    case absolute
+    case group
+    case sourceRoot
+    case buildProductsDir
+    case sdkRoot
+    case developerDir
+    case custom(String)
+
+    private static let noneValue = ""
+    private static let absoluteValue = "<absolute>"
+    private static let groupValue = "<group>"
+    private static let sourceRootValue = "SOURCE_ROOT"
+    private static let buildProductsDirValue = "BUILT_PRODUCTS_DIR"
+    private static let sdkRootValue = "SDKROOT"
+    private static let developerDirValue = "DEVELOPER_DIR"
+
+    public init(value: String) {
+        switch value {
+            case PBXSourceTree.noneValue:
+                self = .none
+            case PBXSourceTree.absoluteValue:
+                self = .absolute
+            case PBXSourceTree.groupValue:
+                self = .group
+            case PBXSourceTree.sourceRootValue:
+                self = .sourceRoot
+            case PBXSourceTree.buildProductsDirValue:
+                self = .buildProductsDir
+            case PBXSourceTree.sdkRootValue:
+                self = .sdkRoot
+            case PBXSourceTree.developerDirValue:
+                self = .developerDir
+            default:
+                self = .custom(value)
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        try self.init(value: decoder.singleValueContainer().decode(String.self))
+    }
+
+    public static func ==(lhs: PBXSourceTree, rhs: PBXSourceTree) -> Bool {
+        switch (lhs, rhs) {
+            case (.none, .none),
+                 (.absolute, .absolute),
+                 (.group, .group),
+                 (.sourceRoot, .sourceRoot),
+                 (.buildProductsDir, .buildProductsDir),
+                 (.sdkRoot, .sdkRoot),
+                 (.developerDir, .developerDir):
+                return true
+
+            case (.custom(let lhsValue), .custom(let rhsValue)):
+                return lhsValue == rhsValue
+
+            case (.none, _),
+                 (.absolute, _),
+                 (.group, _),
+                 (.sourceRoot, _),
+                 (.buildProductsDir, _),
+                 (.sdkRoot, _),
+                 (.developerDir, _),
+                 (.custom, _):
+                return false
+        }
+    }
+
+    public var description: String {
+        switch self {
+            case .none:
+                return PBXSourceTree.noneValue
+            case .absolute:
+                return PBXSourceTree.absoluteValue
+            case .group:
+                return PBXSourceTree.groupValue
+            case .sourceRoot:
+                return PBXSourceTree.sourceRootValue
+            case .buildProductsDir:
+                return PBXSourceTree.buildProductsDirValue
+            case .sdkRoot:
+                return PBXSourceTree.sdkRootValue
+            case .developerDir:
+                return PBXSourceTree.developerDirValue
+            case .custom(let value):
+                return value
+        }
+    }
 }
 
 // MARK: - PBXSourceTree Extension (PlistValue)
@@ -17,7 +99,7 @@ public enum PBXSourceTree: String, Hashable, Decodable {
 extension PBXSourceTree {
     
     func plist() -> PlistValue {
-        return .string(CommentedString(self.rawValue))
+        return .string(CommentedString(String(describing: self)))
     }
 
 }

--- a/Tests/xcprojTests/PBXFileElementSpec.swift
+++ b/Tests/xcprojTests/PBXFileElementSpec.swift
@@ -33,28 +33,6 @@ final class PBXFileElementSpec: XCTestCase {
         XCTAssertEqual(subject, another)
     }
 
-    func test_init_failsIfPathIsMissing() {
-        var dictionary = testDictionary()
-        dictionary.removeValue(forKey: "path")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
-        let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXFileElement.self, from: data)
-            XCTAssertTrue(false, "Expected to throw but it didn't")
-        } catch {}
-    }
-
-    func test_init_failsIfNameIsMissing() {
-        var dictionary = testDictionary()
-        dictionary.removeValue(forKey: "name")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
-        let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXFileElement.self, from: data)
-            XCTAssertTrue(false, "Expected to throw but it didn't")
-        } catch {}
-    }
-
     func test_hashValue_returnsTheReferenceHashValue() {
         XCTAssertEqual(subject.hashValue, subject.reference.hashValue)
     }

--- a/Tests/xcprojTests/PBXFileReferenceSpec.swift
+++ b/Tests/xcprojTests/PBXFileReferenceSpec.swift
@@ -31,17 +31,6 @@ final class PBXFileReferenceSpec: XCTestCase {
         XCTAssertEqual(PBXFileReference.isa, "PBXFileReference")
     }
 
-    func test_init_failsIfNameIsMissing() {
-        var dictionary = testDictionary()
-        dictionary.removeValue(forKey: "name")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
-        let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXFileReference.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
-    }
-
     func test_equal_returnsTheCorrectValue() {
         let another = PBXFileReference(reference: "ref",
                                        sourceTree: .absolute,

--- a/Tests/xcprojTests/PBXGroupSpec.swift
+++ b/Tests/xcprojTests/PBXGroupSpec.swift
@@ -24,17 +24,6 @@ final class PBXGroupSpec: XCTestCase {
         XCTAssertEqual(subject.tabWidth, nil)
     }
 
-    func test_init_failsIfChildrenIsMissing() {
-        var dictionary = testDictionary()
-        dictionary.removeValue(forKey: "children")
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
-        let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
-    }
-
     func test_isa_returnsTheCorrectValue() {
         XCTAssertEqual(PBXGroup.isa, "PBXGroup")
     }

--- a/Tests/xcprojTests/PBXSourceTreeSpec.swift
+++ b/Tests/xcprojTests/PBXSourceTreeSpec.swift
@@ -6,60 +6,65 @@ import XCTest
 final class PBXSourceTreeSpec: XCTestCase {
 
     func test_none_hasTheCorrectValue() {
-        XCTAssertEqual(PBXSourceTree.none.rawValue, "")
+        XCTAssertEqual(String(describing: PBXSourceTree.none), "")
     }
 
     func test_absolute_hasTheCorrectValue() {
-        XCTAssertEqual(PBXSourceTree.absolute.rawValue, "<absolute>")
+        XCTAssertEqual(String(describing: PBXSourceTree.absolute), "<absolute>")
     }
 
     func test_group_hasTheCorrectValue() {
-        XCTAssertEqual(PBXSourceTree.group.rawValue, "<group>")
+        XCTAssertEqual(String(describing: PBXSourceTree.group), "<group>")
     }
 
     func test_sourceRoot_hasTheCorrectValue() {
-        XCTAssertEqual(PBXSourceTree.sourceRoot.rawValue, "SOURCE_ROOT")
+        XCTAssertEqual(String(describing: PBXSourceTree.sourceRoot), "SOURCE_ROOT")
     }
 
     func test_buildProductsDir_hasTheCorrectValue() {
-        XCTAssertEqual(PBXSourceTree.buildProductsDir.rawValue, "BUILT_PRODUCTS_DIR")
+        XCTAssertEqual(String(describing: PBXSourceTree.buildProductsDir), "BUILT_PRODUCTS_DIR")
     }
 
     func test_sdkRoot_hasTheCorrectValue() {
-        XCTAssertEqual(PBXSourceTree.sdkRoot.rawValue, "SDKROOT")
+        XCTAssertEqual(String(describing: PBXSourceTree.sdkRoot), "SDKROOT")
     }
     
     func test_developerDir_hasTheCorrectValue() {
-        XCTAssertEqual(PBXSourceTree.developerDir.rawValue, "DEVELOPER_DIR")
+        XCTAssertEqual(String(describing: PBXSourceTree.developerDir), "DEVELOPER_DIR")
     }
 
     func test_plistReturnsTheRightValue_whenItsNone() {
-        let expected = PlistValue.string(CommentedString(PBXSourceTree.none.rawValue))
+        let expected = PlistValue.string(CommentedString(String(describing: PBXSourceTree.none)))
         XCTAssertEqual(PBXSourceTree.none.plist(), expected)
     }
 
     func test_plistReturnsTheRightValue_whenItsAbsolute() {
-        let expected = PlistValue.string(CommentedString(PBXSourceTree.absolute.rawValue))
+        let expected = PlistValue.string(CommentedString(String(describing: PBXSourceTree.absolute)))
         XCTAssertEqual(PBXSourceTree.absolute.plist(), expected)
     }
 
     func test_plistReturnsTheRightValue_whenItsGroup() {
-        let expected = PlistValue.string(CommentedString(PBXSourceTree.group.rawValue))
+        let expected = PlistValue.string(CommentedString(String(describing: PBXSourceTree.group)))
         XCTAssertEqual(PBXSourceTree.group.plist(), expected)
     }
 
     func test_plistReturnsTheRightValue_whenItsSourceRoot() {
-        let expected = PlistValue.string(CommentedString(PBXSourceTree.sourceRoot.rawValue))
+        let expected = PlistValue.string(CommentedString(String(describing: PBXSourceTree.sourceRoot)))
         XCTAssertEqual(PBXSourceTree.sourceRoot.plist(), expected)
     }
 
     func test_plistReturnsTheRightValue_whenItsBuildProductsDir() {
-        let expected = PlistValue.string(CommentedString(PBXSourceTree.buildProductsDir.rawValue))
+        let expected = PlistValue.string(CommentedString(String(describing: PBXSourceTree.buildProductsDir)))
         XCTAssertEqual(PBXSourceTree.buildProductsDir.plist(), expected)
     }
 
     func test_plistReturnsTheRightValue_whenItsSdkRoot() {
-        let expected = PlistValue.string(CommentedString(PBXSourceTree.sdkRoot.rawValue))
+        let expected = PlistValue.string(CommentedString(String(describing: PBXSourceTree.sdkRoot)))
         XCTAssertEqual(PBXSourceTree.sdkRoot.plist(), expected)
+    }
+
+    func test_plistReturnsTheRightValue_whenCustom() {
+        let expected = PlistValue.string(CommentedString("CustomSourceTree"))
+        XCTAssertEqual(PBXSourceTree.custom("CustomSourceTree").plist(), expected)
     }
 }

--- a/Tests/xcprojTests/PBXVariantGroupSpec.swift
+++ b/Tests/xcprojTests/PBXVariantGroupSpec.swift
@@ -21,17 +21,6 @@ final class PBXVariantGroupSpec: XCTestCase {
         XCTAssertEqual(subject.sourceTree, .group)
     }
 
-    func test_init_failsIfTheSourceTreeIsWrong() {
-        var dictionary = testDictionary()
-        dictionary["sourceTree"] = "asdgasdgas"
-        let data = try! JSONSerialization.data(withJSONObject: dictionary, options: [])
-        let decoder = JSONDecoder()
-        do {
-            _ = try decoder.decode(PBXVariantGroup.self, from: data)
-            XCTAssertTrue(false, "Expected to throw an error but it didn't")
-        } catch {}
-    }
-
     func test_itHasTheCorrectIsa() {
         XCTAssertEqual(PBXVariantGroup.isa, "PBXVariantGroup")
     }


### PR DESCRIPTION
### Short description 📝
An esoteric feature of Xcode allows people to specify a custom variable for the source tree (e.g. `DERIVED_FILE_DIR`), which wasn't supported by xcproj.

### Solution 📦
 Convert `PBXSourceTree` to an enum with an associated value so we can load this information.

With this change, loading a `PBXSourceTree` from a string always succeeds, which identified a number of obsolete tests that were attempting to check for a throw when a value was missing from the object's encoded representation. I removed those tests.

### Implementation 👩‍💻👨‍💻
- [x] Convert `PBXSourceTree` to manually initialize from a string and convert to a string
- [x] Update `PBXSourceTree` to manually determine equality. Perhaps this is another candidate for Sourcery.
- [x] Add support decoding and encoding custom PBXSourceTree values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/198)
<!-- Reviewable:end -->
