### PR TITLE
Fix PBXReferenceProxy Encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Optimised escaping of CommentedString https://github.com/xcodeswift/xcproj/pull/195 by @kastiglione
 - Optimised performance of object lookups https://github.com/xcodeswift/xcproj/pull/191 by @kastiglione
 - fixed PBXLegacyTarget write order https://github.com/xcodeswift/xcproj/pull/199 by @kastiglione
+- fixed PBXReferenceTarget encoding in pbxproj file https://github.com/xcodeswift/xcproj/pull/202 by @briantkelley
 
 ## 1.7.0
 

--- a/Sources/xcproj/PBXProjEncoder.swift
+++ b/Sources/xcproj/PBXProjEncoder.swift
@@ -39,6 +39,7 @@ final class PBXProjEncoder {
         write(section: "PBXLegacyTarget", proj: proj, object: proj.objects.legacyTargets)
         write(section: "PBXNativeTarget", proj: proj, object: proj.objects.nativeTargets)
         write(section: "PBXProject", proj: proj, object: proj.objects.projects)
+        write(section: "PBXReferenceProxy", proj: proj, object: proj.objects.referenceProxies)
         write(section: "PBXResourcesBuildPhase", proj: proj, object: proj.objects.resourcesBuildPhases)
         write(section: "PBXShellScriptBuildPhase", proj: proj, object: proj.objects.shellScriptBuildPhases)
         write(section: "PBXSourcesBuildPhase", proj: proj, object: proj.objects.sourcesBuildPhases)

--- a/Sources/xcproj/PBXReferenceProxy.swift
+++ b/Sources/xcproj/PBXReferenceProxy.swift
@@ -68,7 +68,7 @@ extension PBXReferenceProxy: PlistSerializable {
     
     func plistKeyAndValue(proj: PBXProj) -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = [:]
-        dictionary["isa"] = .string(CommentedString(PBXVariantGroup.isa))
+        dictionary["isa"] = .string(CommentedString(PBXReferenceProxy.isa))
         if let fileType = fileType {
             dictionary["fileType"] = .string(CommentedString(fileType))
         }


### PR DESCRIPTION
Add the PBXReferenceProxy section to the pbxproj file and fix the isa used when generating the object dictionary.

### Short description 📝
The PBXReferenceProxy section was omitted from the pbxproj file and its dictionary was using the wrong isa.

### Solution 📦
Add the PBXReferenceProxy section to the encoding of the plist, maintaining alphabetical, and use `PBXReferenceProxy.isa` when writing its isa.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/202)
<!-- Reviewable:end -->
