### PR TITLE
Use (null) in comment when PBXBuildFile.name == nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Optimised escaping of CommentedString https://github.com/xcodeswift/xcproj/pull/195 by @kastiglione
 - Optimised performance of object lookups https://github.com/xcodeswift/xcproj/pull/191 by @kastiglione
 - fixed PBXLegacyTarget write order https://github.com/xcodeswift/xcproj/pull/199 by @kastiglione
+- fixed comment generation of PBXBuildFiles without a name https://github.com/xcodeswift/xcproj/pull/203 by @briantkelley
 
 ## 1.7.0
 

--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -80,9 +80,7 @@ extension PBXBuildFile: PlistSerializable {
             dictionary["settings"] = settings.plist()
         }
         let buildPhaseName = proj.objects.buildPhaseName(buildFileReference: reference)
-        let comment = fileName.flatMap({ fileName -> String? in
-            buildPhaseName.flatMap({"\(fileName) in \($0)"})
-        })
+        let comment = buildPhaseName.flatMap({"\(fileName ?? "(null)") in \($0)"})
         return (key: CommentedString(self.reference, comment: comment),
                 value: .dictionary(dictionary))
     }

--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -65,14 +65,8 @@ public class PBXBuildPhase: PBXObject, Equatable {
         dictionary["files"] = .array(files.map { fileReference in
             let name = proj.objects.fileName(buildFileReference: fileReference)
             let type = proj.objects.buildPhaseName(buildFileReference: fileReference)
-            let comment = name
-                .flatMap({ fileName -> String? in
-                    if let type = type {
-                        return "\(fileName) in \(type)"
-                    } else {
-                        return fileName
-                    }
-                })
+            let fileName = name ?? "(null)"
+            let comment = (type.flatMap { "\(fileName) in \($0)" }) ?? name
             return .string(CommentedString(fileReference, comment: comment))
         })
         dictionary["runOnlyForDeploymentPostprocessing"] = .string(CommentedString("\(runOnlyForDeploymentPostprocessing)"))


### PR DESCRIPTION
### Short description 📝
When a `PBXBuildFile` is missing the name property, xcproj doesn't emit a comment for the encoding of the object or references to it. Xcode emites the string `"(null)"`.

### Solution 📦
Update the comment generation of `PBXBuildFile` and comment generation in `PBXBuildPhase` to use the string `"(null)"` when the `PBXProj.Objects.fileName(buildFileReference:)` return `nil`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/203)
<!-- Reviewable:end -->
