### PR TITLE
Change CLI fileExtension to nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fix Xcode 9.2 warning https://github.com/xcodeswift/xcproj/pull/209 by @keith
+- macOS CLI targets now have a nil extension, instead of an empty string https://github.com/xcodeswift/xcproj/pull/208 by @keith
 
 ## 2.0.0
 

--- a/Sources/xcproj/PBXProductType.swift
+++ b/Sources/xcproj/PBXProductType.swift
@@ -41,7 +41,7 @@ public enum PBXProductType: String, Decodable {
         case .appExtension, .tvExtension, .watchExtension, .watch2Extension, .messagesExtension, .stickerPack, .xcodeExtension:
             return "appex"
         case .commandLineTool:
-            return ""
+            return nil
         case .xpcService:
             return "xpc"
         case .ocUnitTestBundle:


### PR DESCRIPTION
The fileExtension property is used upstream to determine the
explicitFileType of the file reference. If that property exists but is
empty Xcode crashes. Previously that was the case with the tool file
type since the product target had an empty explicitFileType. With this
change it now omits that property instead, and still has no extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/208)
<!-- Reviewable:end -->
