### PR TITLE
Remove characters call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Fixed
+- Fix Xcode 9.2 warning https://github.com/xcodeswift/xcproj/pull/209 by @keith
+
 ## 2.0.0
 
 ### Added

--- a/Sources/xcproj/String+Extras.swift
+++ b/Sources/xcproj/String+Extras.swift
@@ -15,7 +15,7 @@ extension String {
         var randomString: String = ""
         
         for _ in 0..<length {
-            let randomValue = arc4random_uniform(UInt32(base.characters.count))
+            let randomValue = arc4random_uniform(UInt32(base.count))
             randomString += "\(base[base.index(base.startIndex, offsetBy: Int(randomValue))])"
         }
         return randomString


### PR DESCRIPTION
This is a warning with Xcode 9.2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/209)
<!-- Reviewable:end -->
