### PR TITLE
Add XCWorkspace group and file reference parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - macOS CLI targets now have a nil extension, instead of an empty string https://github.com/xcodeswift/xcproj/pull/208 by @keith
 - Fix unnecessary quotations in CommentedString https://github.com/xcodeswift/xcproj/pull/211 by @allu22
 
+### Changed
+- **Breaking:** `XCWorkspace.Data` renamed to `XCWorkspaceData` and removed `references`.
+
 ## 2.0.0
 
 ### Added

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -28,6 +28,10 @@
 		BF2311546502 /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3255351901 /* Bool+Extras.swift */; };
 		BF2547585701 /* PBXProjObjects+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8449186301 /* PBXProjObjects+Helpers.swift */; };
 		BF2547585702 /* PBXProjObjects+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8449186301 /* PBXProjObjects+Helpers.swift */; };
+		BF2605514001 /* XCWorkspaceDataGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5395076701 /* XCWorkspaceDataGroup.swift */; };
+		BF2605514002 /* XCWorkspaceDataGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5395076701 /* XCWorkspaceDataGroup.swift */; };
+		BF2887207901 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6189630601 /* XCWorkspaceDataFileRef.swift */; };
+		BF2887207902 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6189630601 /* XCWorkspaceDataFileRef.swift */; };
 		BF3107150401 /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5296652601 /* PBXProductType.swift */; };
 		BF3107150402 /* PBXProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5296652601 /* PBXProductType.swift */; };
 		BF3149206801 /* XCBreakpointList.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8244170301 /* XCBreakpointList.swift */; };
@@ -47,6 +51,8 @@
 		BF3882936802 /* PBXFileElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1364894901 /* PBXFileElement.swift */; };
 		BF4064216601 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2127460001 /* PBXNativeTarget.swift */; };
 		BF4064216602 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR2127460001 /* PBXNativeTarget.swift */; };
+		BF4217534501 /* XCWorkspaceDataElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7040398601 /* XCWorkspaceDataElement.swift */; };
+		BF4217534502 /* XCWorkspaceDataElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7040398601 /* XCWorkspaceDataElement.swift */; };
 		BF4292481201 /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4811062301 /* XCSharedData.swift */; };
 		BF4292481202 /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4811062301 /* XCSharedData.swift */; };
 		BF4321991401 /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7045651001 /* PBXSourcesBuildPhase.swift */; };
@@ -58,6 +64,8 @@
 		BF4535722201 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4352207101 /* XCConfig.swift */; };
 		BF4535722202 /* XCConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4352207101 /* XCConfig.swift */; };
 		BF4805463201 /* PathKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FR8873340702 /* PathKit.framework */; };
+		BF4909993601 /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1474891601 /* XCWorkspaceDataElementLocationType.swift */; };
+		BF4909993602 /* XCWorkspaceDataElementLocationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR1474891601 /* XCWorkspaceDataElementLocationType.swift */; };
 		BF5094034701 /* PBXProj+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7428998701 /* PBXProj+Helpers.swift */; };
 		BF5094034702 /* PBXProj+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7428998701 /* PBXProj+Helpers.swift */; };
 		BF5139737101 /* PBXBuildRule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR7054588301 /* PBXBuildRule.swift */; };
@@ -123,6 +131,7 @@
 		FR1312420901 /* XcodeProj.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeProj.swift; sourceTree = "<group>"; };
 		FR1364894901 /* PBXFileElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXFileElement.swift; sourceTree = "<group>"; };
 		FR1452498301 /* XCWorkspaceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceData.swift; sourceTree = "<group>"; };
+		FR1474891601 /* XCWorkspaceDataElementLocationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataElementLocationType.swift; sourceTree = "<group>"; };
 		FR1827232901 /* PBXReferenceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXReferenceProxy.swift; sourceTree = "<group>"; };
 		FR1870303001 /* PBXLegacyTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXLegacyTarget.swift; sourceTree = "<group>"; };
 		FR2127460001 /* PBXNativeTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXNativeTarget.swift; sourceTree = "<group>"; };
@@ -151,13 +160,16 @@
 		FR5186857101 /* CommentedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentedString.swift; sourceTree = "<group>"; };
 		FR5190097701 /* PBXResourcesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXResourcesBuildPhase.swift; sourceTree = "<group>"; };
 		FR5296652601 /* PBXProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProductType.swift; sourceTree = "<group>"; };
+		FR5395076701 /* XCWorkspaceDataGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataGroup.swift; sourceTree = "<group>"; };
 		FR5460675201 /* PBXCopyFilesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXCopyFilesBuildPhase.swift; sourceTree = "<group>"; };
 		FR6006730201 /* Dictionary+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
+		FR6189630601 /* XCWorkspaceDataFileRef.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataFileRef.swift; sourceTree = "<group>"; };
 		FR6357036901 /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
 		FR6447358001 /* AEXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AEXML.framework; sourceTree = "<group>"; };
 		FR6447358002 /* AEXML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = AEXML.framework; sourceTree = "<group>"; };
 		FR6754770501 /* XCVersionGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCVersionGroup.swift; sourceTree = "<group>"; };
 		FR6980748501 /* PBXBuildFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildFile.swift; sourceTree = "<group>"; };
+		FR7040398601 /* XCWorkspaceDataElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataElement.swift; sourceTree = "<group>"; };
 		FR7045651001 /* PBXSourcesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXSourcesBuildPhase.swift; sourceTree = "<group>"; };
 		FR7054588301 /* PBXBuildRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildRule.swift; sourceTree = "<group>"; };
 		FR7128364401 /* String+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extras.swift"; sourceTree = "<group>"; };
@@ -294,6 +306,10 @@
 				FR6754770501 /* XCVersionGroup.swift */,
 				FR2671862701 /* XCWorkspace.swift */,
 				FR1452498301 /* XCWorkspaceData.swift */,
+				FR7040398601 /* XCWorkspaceDataElement.swift */,
+				FR1474891601 /* XCWorkspaceDataElementLocationType.swift */,
+				FR6189630601 /* XCWorkspaceDataFileRef.swift */,
+				FR5395076701 /* XCWorkspaceDataGroup.swift */,
 				FR1312420901 /* XcodeProj.swift */,
 			);
 			name = xcproj;
@@ -468,6 +484,10 @@
 				BF3723071401 /* XCVersionGroup.swift in Sources */,
 				BF7333567601 /* XCWorkspace.swift in Sources */,
 				BF8826568101 /* XCWorkspaceData.swift in Sources */,
+				BF4217534501 /* XCWorkspaceDataElement.swift in Sources */,
+				BF4909993601 /* XCWorkspaceDataElementLocationType.swift in Sources */,
+				BF2887207901 /* XCWorkspaceDataFileRef.swift in Sources */,
+				BF2605514001 /* XCWorkspaceDataGroup.swift in Sources */,
 				BF8332506301 /* XcodeProj.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -527,6 +547,10 @@
 				BF3723071402 /* XCVersionGroup.swift in Sources */,
 				BF7333567602 /* XCWorkspace.swift in Sources */,
 				BF8826568102 /* XCWorkspaceData.swift in Sources */,
+				BF4217534502 /* XCWorkspaceDataElement.swift in Sources */,
+				BF4909993602 /* XCWorkspaceDataElementLocationType.swift in Sources */,
+				BF2887207902 /* XCWorkspaceDataFileRef.swift in Sources */,
+				BF2605514002 /* XCWorkspaceDataGroup.swift in Sources */,
 				BF8332506302 /* XcodeProj.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Fixtures/Workspace.xcworkspace/contents.xcworkspacedata
+++ b/Fixtures/Workspace.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <Group
+      location = "group:iOS"
+      name = "iOS">
+      <FileRef
+         location = "group:../WithoutWorkspace/WithoutWorkspace.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "container:iOS/BuildSettings.xcodeproj">
+      </FileRef>
+   </Group>
+   <Group
+      location = "container:Schemes"
+      name = "Schemes">
+   </Group>
+   <FileRef
+      location = "absolute:/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app">
+   </FileRef>
+   <FileRef
+      location = "developer:Applications/Simulator.app">
+   </FileRef>
+</Workspace>

--- a/Sources/xcproj/XCWorkspace.swift
+++ b/Sources/xcproj/XCWorkspace.swift
@@ -5,7 +5,7 @@ import PathKit
 final public class XCWorkspace {
 
     /// Workspace data
-    public var data: XCWorkspace.Data
+    public var data: XCWorkspaceData
 
     // MARK: - Init
 
@@ -23,13 +23,13 @@ final public class XCWorkspace {
         if xcworkspaceDataPaths.count == 0 {
             self.init()
         } else {
-            try self.init(data: XCWorkspace.Data(path: xcworkspaceDataPaths.first!))
+            try self.init(data: XCWorkspaceData(path: xcworkspaceDataPaths.first!))
         }
     }
     
     /// Initializes a default workspace with a single reference that points to self:
     public convenience init() {
-        let data = XCWorkspace.Data(references: [ .other(location: "self:") ])
+        let data = XCWorkspaceData(children: [.file(.init(location: .self("")))])
         self.init(data: data)
     }
     
@@ -45,7 +45,7 @@ final public class XCWorkspace {
     ///
     /// - Parameters:
     ///   - data: workspace data.
-    public init(data: XCWorkspace.Data) {
+    public init(data: XCWorkspaceData) {
         self.data = data
     }
     

--- a/Sources/xcproj/XCWorkspaceDataElement.swift
+++ b/Sources/xcproj/XCWorkspaceDataElement.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public enum XCWorkspaceDataElement {
+
+    public enum Error: Swift.Error {
+        case unknownName(String)
+    }
+
+    case file(XCWorkspaceDataFileRef)
+    case group(XCWorkspaceDataGroup)
+}
+
+extension XCWorkspaceDataElement: Equatable {
+
+    public static func == (lhs: XCWorkspaceDataElement, rhs: XCWorkspaceDataElement) -> Bool {
+        switch (lhs, rhs) {
+        case let (.file(lhs), .file(rhs)):
+            return lhs == rhs
+        case let (.group(lhs), .group(rhs)):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+}
+

--- a/Sources/xcproj/XCWorkspaceDataElementLocationType.swift
+++ b/Sources/xcproj/XCWorkspaceDataElementLocationType.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+public enum XCWorkspaceDataElementLocationType {
+
+    public enum Error: Swift.Error {
+        case missingSchema
+    }
+
+    case absolute(String)   // "Absolute path"
+    case container(String)  // "Relative to container"
+    case developer(String)  // "Relative to Developer Directory"
+    case group(String)      // "Relative to group"
+    case `self`(String)     // Single project workspace in xcodeproj directory
+    case other(String, String)
+
+    public var schema: String {
+        switch self {
+        case .absolute:
+            return "absolute"
+        case .container:
+            return "container"
+        case .developer:
+            return "developer"
+        case .group:
+            return "group"
+        case .self:
+            return "self"
+        case let .other(schema, _):
+            return schema
+        }
+    }
+
+    public var path: String {
+        switch self {
+        case let .absolute(path):
+            return path
+        case let .container(path):
+            return path
+        case let .developer(path):
+            return path
+        case let .group(path):
+            return path
+        case let .self(path):
+            return path
+        case let .other(_, path):
+            return path
+        }
+    }
+
+    public init(string: String) throws {
+        let elements = string.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+        guard let schema = elements.first.map(String.init) else {
+            throw Error.missingSchema
+        }
+        let path = String(elements.last ?? "")
+        switch schema {
+        case "absolute":
+            self = .absolute(path)
+        case "container":
+            self = .container(path)
+        case "developer":
+            self = .developer(path)
+        case "group":
+            self = .group(path)
+        case "self":
+            self = .self(path)
+        default:
+            self = .other(schema, path)
+        }
+    }
+}
+
+extension XCWorkspaceDataElementLocationType: CustomStringConvertible {
+
+    public var description: String {
+        return "\(schema):\(path)"
+    }
+}
+
+extension XCWorkspaceDataElementLocationType: Equatable {
+
+    public static func == (lhs: XCWorkspaceDataElementLocationType, rhs: XCWorkspaceDataElementLocationType) -> Bool {
+        switch (lhs, rhs) {
+        case let (.absolute(lhs), .absolute(rhs)):
+            return lhs == rhs
+        case let (.container(lhs), .container(rhs)):
+            return lhs == rhs
+        case let (.developer(lhs), .developer(rhs)):
+            return lhs == rhs
+        case let (.group(lhs), .group(rhs)):
+            return lhs == rhs
+        case let (.self(lhs), .self(rhs)):
+            return lhs == rhs
+        case let (.other(lhs), .other(rhs)):
+            return lhs.0 == rhs.0 && lhs.1 == rhs.1
+        default: return false
+        }
+    }
+}

--- a/Sources/xcproj/XCWorkspaceDataFileRef.swift
+++ b/Sources/xcproj/XCWorkspaceDataFileRef.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+final public class XCWorkspaceDataFileRef {
+
+    public var location: XCWorkspaceDataElementLocationType
+
+    public init(location: XCWorkspaceDataElementLocationType) {
+        self.location = location
+    }
+}
+
+extension XCWorkspaceDataFileRef: Equatable {
+
+    public static func == (lhs: XCWorkspaceDataFileRef, rhs: XCWorkspaceDataFileRef) -> Bool {
+        return lhs.location == rhs.location
+    }
+}

--- a/Sources/xcproj/XCWorkspaceDataGroup.swift
+++ b/Sources/xcproj/XCWorkspaceDataGroup.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+final public class XCWorkspaceDataGroup {
+
+    public var location: XCWorkspaceDataElementLocationType
+    public var name: String?
+    public var children: [XCWorkspaceDataElement]
+
+    public init(location: XCWorkspaceDataElementLocationType, name: String?, children: [XCWorkspaceDataElement]) {
+        self.location = location
+        self.name = name
+        self.children = children
+    }
+}
+
+extension XCWorkspaceDataGroup: Equatable {
+
+    public static func == (lhs: XCWorkspaceDataGroup, rhs: XCWorkspaceDataGroup) -> Bool {
+        return lhs.location == rhs.location &&
+            lhs.name == rhs.name &&
+            lhs.children == rhs.children
+    }
+}

--- a/Sources/xcproj/XcodeProj.swift
+++ b/Sources/xcproj/XcodeProj.swift
@@ -60,12 +60,12 @@ extension XcodeProj: Writable {
 
     public func write(path: Path, override: Bool = true) throws {
         try path.mkpath()
-        try writeWorkSpace(path: path, override: override)
+        try writeWorkspace(path: path, override: override)
         try writePBXProj(path: path, override: override)
         try writeSharedData(path: path, override: override)
     }
 
-    fileprivate func writeWorkSpace(path: Path, override: Bool) throws {
+    fileprivate func writeWorkspace(path: Path, override: Bool) throws {
         try workspace.write(path: path + "project.xcworkspace", override: override)
     }
 

--- a/Tests/xcprojTests/XCWorkspaceDataSpec.swift
+++ b/Tests/xcprojTests/XCWorkspaceDataSpec.swift
@@ -5,18 +5,20 @@ import xcproj
 
 final class XCWorkspaceDataSpec: XCTestCase {
 
-    var subject: XCWorkspace.Data!
-    var fileRef: XCWorkspace.Data.FileRef!
+    var subject: XCWorkspaceData!
+    var fileRef: XCWorkspaceDataFileRef!
 
     override func setUp() {
         super.setUp()
-        fileRef = "path"
-        subject = XCWorkspace.Data(references: [])
+        fileRef = XCWorkspaceDataFileRef(
+            location: .self("path")
+        )
+        subject = XCWorkspaceData(children: [])
     }
 
 
     func test_equal_returnsTheCorrectValue() {
-        let another = XCWorkspace.Data(references: [])
+        let another = XCWorkspaceData(children: [])
         XCTAssertEqual(subject, another)
     }
 
@@ -24,27 +26,90 @@ final class XCWorkspaceDataSpec: XCTestCase {
 
 final class XCWorkspaceDataIntegrationSpec: XCTestCase {
 
-    func test_init_returnsTheModelWithTheRightProperties() {
+    func test_init_returnsTheModelWithTheRightProperties() throws {
         let path = fixturePath()
-        let got = try? XCWorkspace.Data(path: path)
-        XCTAssertNotNil(got?.references.first?.project)
+        let got = try XCWorkspaceData(path: path)
+        if case let XCWorkspaceDataElement.file(location: fileRef) = got.children.first! {
+            XCTAssertEqual(fileRef.location, .self(""))
+        } else {
+            XCTAssertTrue(false, "Expected file reference")
+        }
     }
 
     func test_init_throwsIfThePathIsWrong() {
         do {
-            _ = try XCWorkspace.Data(path: Path("test"))
+            _ = try XCWorkspace(path: Path("test"))
             XCTAssertTrue(false, "Expected to throw an error but it didn't")
         } catch {}
     }
 
     func test_write() {
-        testWrite(from: fixturePath(),
-                  initModel: { try? XCWorkspace.Data(path: $0) },
-                  modify: {
-                    $0.references.append( .file(path: "shakira"))
-                    return $0
-                    }) { (before, after) in
-                    XCTAssertTrue(after.references.filter{ $0.description.contains("shakira")}.count == 1)
+        testWrite(
+            from: fixturePath(),
+            initModel: { try? XCWorkspaceData(path: $0) },
+            modify: {
+                $0.children.append(
+                    .group(.init(location: .self("shakira"),
+                                 name: "shakira",
+                                 children: [])
+                    )
+                )
+                return $0
+        },
+            assertion: { (before, after) in
+                XCTAssertEqual(before, after)
+                XCTAssertEqual(after.children.count, 2)
+
+                switch after.children.last {
+                case let .group(group)?:
+                    XCTAssertEqual(group.name, "shakira")
+                    XCTAssertEqual(group.children.count, 0)
+                default:
+                    XCTAssertTrue(false, "Expected group")
+                }
+        })
+    }
+
+    func test_init_returnsAllChildren() throws {
+        let workspace = try fixtureWorkspace()
+        XCTAssertEqual(workspace.data.children.count, 4)
+    }
+
+    func test_init_returnsNestedElements() throws {
+        let workspace = try fixtureWorkspace()
+        if case let XCWorkspaceDataElement.group(group) = workspace.data.children.first! {
+            XCTAssertEqual(group.children.count, 2)
+        } else {
+            XCTAssertTrue(false, "Expected group")
+        }
+    }
+
+    func test_init_returnsAllLocationTypes() throws {
+        let workspace = try fixtureWorkspace()
+
+        if case let XCWorkspaceDataElement.group(group) = workspace.data.children[0] {
+            if case let XCWorkspaceDataElement.file(fileRef) = group.children[0] {
+                XCTAssertEqual(fileRef.location, .group("../WithoutWorkspace/WithoutWorkspace.xcodeproj"))
+            } else {
+                XCTAssertTrue(false, "Expected fileRef")
+            }
+            if case let XCWorkspaceDataElement.file(fileRef) = group.children[1] {
+                XCTAssertEqual(fileRef.location, .container("iOS/BuildSettings.xcodeproj"))
+            } else {
+                XCTAssertTrue(false, "Expected fileRef")
+            }
+        } else {
+            XCTAssertTrue(false, "Expected group")
+        }
+        if case let XCWorkspaceDataElement.file(fileRef) = workspace.data.children[2] {
+            XCTAssertEqual(fileRef.location, .absolute("/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app"))
+        } else {
+            XCTAssertTrue(false, "Expected fileRef")
+        }
+        if case let XCWorkspaceDataElement.file(fileRef) = workspace.data.children[3] {
+            XCTAssertEqual(fileRef.location, .developer("Applications/Simulator.app"))
+        } else {
+            XCTAssertTrue(false, "Expected fileRef")
         }
     }
 
@@ -52,6 +117,11 @@ final class XCWorkspaceDataIntegrationSpec: XCTestCase {
 
     private func fixturePath() -> Path {
         return fixturesPath() + Path("iOS/Project.xcodeproj/project.xcworkspace/contents.xcworkspacedata")
+    }
+
+    private func fixtureWorkspace() throws -> XCWorkspace {
+        let path = fixturesPath() + Path("Workspace.xcworkspace")
+        return try XCWorkspace(path: path)
     }
 
 }

--- a/Tests/xcprojTests/XCWorkspaceSpec.swift
+++ b/Tests/xcprojTests/XCWorkspaceSpec.swift
@@ -19,8 +19,7 @@ final class XCWorkspaceIntegrationSpec: XCTestCase {
     }
     
     func test_init_returnsAWorkspaceWithTheCorrectReference() {
-        XCTAssertEqual(XCWorkspace().data.references.count, 1)
-        XCTAssertEqual(XCWorkspace().data.references.first, .other(location: "self:"))
+        XCTAssertEqual(XCWorkspace().data.children.count, 1)
+        XCTAssertEqual(XCWorkspace().data.children.first, .file(.init(location: .self(""))))
     }
-
 }

--- a/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
@@ -23,9 +23,15 @@ final class XcodeProjIntegrationSpec: XCTestCase {
                   modify: { $0 })
     }
     
-    func test_init_usesAnEmptyWorkspace_whenItsMissing() {
-        let got = projectWithoutWorkspace()
-        XCTAssertNotNil(got)
+    func test_init_usesAnEmptyWorkspace_whenItsMissing() throws {
+        let got = try projectWithoutWorkspace()
+        XCTAssertEqual(got.workspace.data.children.count, 1)
+
+        if case let XCWorkspaceDataElement.file(fileRef) = got.workspace.data.children[0] {
+            XCTAssertEqual(fileRef.location.schema, "self")
+        } else {
+            XCTAssertTrue(false, "Expected \(XCWorkspaceDataElement.file)")
+        }
     }
 
     func test_init_setsCorrectProjectName() {
@@ -79,7 +85,7 @@ final class XcodeProjIntegrationSpec: XCTestCase {
         return try? XcodeProj(path: fixtureiOSProjectPath())
     }
     
-    private func projectWithoutWorkspace() -> XcodeProj? {
-        return try? XcodeProj(path: fixtureWithoutWorkspaceProjectPath())
+    private func projectWithoutWorkspace() throws -> XcodeProj {
+        return try XcodeProj(path: fixtureWithoutWorkspaceProjectPath())
     }
 }


### PR DESCRIPTION
### Short description 📝
Currently `XCWorkspace.Data` only supports `FileRef` elements from `workspacedata` file. And in some cases is incorrectly parses `Group` element as `FileRef`.

### Solution 📦
Add support for both `Group` and `FileRef` elements in `XCWorkspace.Data`.

I moved `XCWorkspace.Data` to `XCWorkspaceData`, because I needed to add additional models _under_ `Data`. If I were to keep nesting them, it would become less readable (If you think otherwise, let me know.)

Currently all `XCWorkspaceData` encoding is done in `XCWorkspaceData.swift` by adding private extensions for other necessary types. This is done to not expose `AEXML` types outside of this file. I am not sure if this is necessary, but decided this way because I personally don't see need to initialise these models from `AEXMLElement`.

One thing I am not sure about is `XCWorkspaceDataElement` enum. Alternative would be to use a protocol but then we would need to downcast when we want concrete types.


### GIF
![gif](https://media.giphy.com/media/3o7absMfvwKhHkFFv2/giphy.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/210)
<!-- Reviewable:end -->
