### PR TITLE
Helper methods required for adding build file to the target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Breaking:** `XCWorkspace.Data` renamed to `XCWorkspaceData` and removed `references`.
 - Improved README examples. https://github.com/xcodeswift/xcproj/pull/212 by @ilyapuchka
 - Added methods to get paths to workspace, project and breakpoints and shemes files, added public methods to write them separatery. https://github.com/xcodeswift/xcproj/pull/215 by @ilyapuchka
+- Added helper methods for adding source file to the project. https://github.com/xcodeswift/xcproj/pull/213 by @ilyapuchka
 
 ## 2.0.0
 

--- a/Fixtures/iOS/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/iOS/Project.xcodeproj/project.pbxproj
@@ -61,13 +61,13 @@
 		04D5C0A21F153921008A2F98 /* Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Private.h; sourceTree = "<group>"; };
 		23766C121EAA3484007A9026 /* iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		23766C151EAA3484007A9026 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		23766C171EAA3484007A9026 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		23766C171EAA3484007A9026 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = /Users/ilyapuchka/dev/xcproj/Fixtures/iOS/iOS/ViewController.swift; sourceTree = "<absolute>"; };
 		23766C1A1EAA3484007A9026 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		23766C1C1EAA3484007A9026 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		23766C1F1EAA3484007A9026 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		23766C211EAA3484007A9026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		23766C261EAA3484007A9026 /* iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		23766C2A1EAA3484007A9026 /* iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTests.swift; sourceTree = "<group>"; };
+		23766C2A1EAA3484007A9026 /* iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = iOSTests.swift; path = iOSTests/iOSTests.swift; sourceTree = SOURCE_ROOT; };
 		23766C2C1EAA3484007A9026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 

--- a/Fixtures/iOS/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/iOS/Project.xcodeproj/project.pbxproj
@@ -61,13 +61,13 @@
 		04D5C0A21F153921008A2F98 /* Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Private.h; sourceTree = "<group>"; };
 		23766C121EAA3484007A9026 /* iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		23766C151EAA3484007A9026 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		23766C171EAA3484007A9026 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ViewController.swift; path = /Users/ilyapuchka/dev/xcproj/Fixtures/iOS/iOS/ViewController.swift; sourceTree = "<absolute>"; };
+		23766C171EAA3484007A9026 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		23766C1A1EAA3484007A9026 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		23766C1C1EAA3484007A9026 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		23766C1F1EAA3484007A9026 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		23766C211EAA3484007A9026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		23766C261EAA3484007A9026 /* iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		23766C2A1EAA3484007A9026 /* iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = iOSTests.swift; path = iOSTests/iOSTests.swift; sourceTree = SOURCE_ROOT; };
+		23766C2A1EAA3484007A9026 /* iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTests.swift; sourceTree = "<group>"; };
 		23766C2C1EAA3484007A9026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 

--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -1,6 +1,18 @@
 import Foundation
 import PathKit
 
+// MARK: - PBXProj Extension (Public)
+
+public extension PBXProj {
+
+    /// Returns project's root group
+    public var rootGroup: PBXGroup {
+        let groupRef = objects.projects[rootObject]!.mainGroup
+        return objects.groups[groupRef]!
+    }
+
+}
+
 // MARK: - PBXProj Extension (Getters)
 
 extension PBXProj {

--- a/Sources/xcproj/PBXProj+Helpers.swift
+++ b/Sources/xcproj/PBXProj+Helpers.swift
@@ -5,10 +5,20 @@ import PathKit
 
 public extension PBXProj {
 
-    /// Returns project's root group
+    /// Returns root project.
+    public var rootProject: PBXProject? {
+        return objects.projects[rootObject]
+    }
+
+    /// Returns root project's root group.
     public var rootGroup: PBXGroup {
-        let groupRef = objects.projects[rootObject]!.mainGroup
-        return objects.groups[groupRef]!
+        guard let rootProject = self.rootProject else {
+            fatalError("Missing root project")
+        }
+        guard let rootGroup = objects.groups[rootProject.mainGroup] else {
+            fatalError("Root project has no root group")
+        }
+        return rootGroup
     }
 
 }

--- a/Sources/xcproj/PBXProjObjects+Helpers.swift
+++ b/Sources/xcproj/PBXProjObjects+Helpers.swift
@@ -93,7 +93,12 @@ public extension PBXProj.Objects {
     ///   - sourceTree: file sourceTree, default is `.group`
     ///   - sourceRoot: path to project's source root.
     /// - Returns: new or existing file and its reference.
-    public func addFile(at filePath: Path, toGroup: PBXGroup, sourceTree: PBXSourceTree = .group, sourceRoot: Path) throws -> (reference: String, file: PBXFileReference) {
+    public func addFile(
+        at filePath: Path,
+        toGroup: PBXGroup,
+        sourceTree: PBXSourceTree = .group,
+        sourceRoot: Path) throws -> (reference: String, file: PBXFileReference) {
+
         guard filePath.isFile else {
             throw XCodeProjEditingError.notAFile(path: filePath)
         }


### PR DESCRIPTION
Resolves https://github.com/xcodeswift/xcproj/issues/120, #40 

### Short description 📝
Added some helper methods required for adding build files

### Solution 📦
With these methods adding a new build file requires just few calls:

```swift
// 1. get target
guard let target = project.pbxproj.objects.targets(named: "MyApp").first else { return }

// 2. if needed add new group for this file
let groups = project.pbxproj.objects.addGroup(named: "Sources/Home", to: project.pbxproj.rootGroup)

// 3. add file to the project, if needed
let (fileRef, _) = project.pbxproj.objects.addFile(at: "Sources/HomeViewController.swift")

// 4. add file to the group, if needed
project.pbxproj.objects.addFile(toGroup: groups[1].group, reference: fileRef)

// 5. add file to the target, if needed
project.pbxproj.objects.addBuildFile(toTarget: target, reference: fileRef)
```

If approved for merge I'll add some integration tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/213)
<!-- Reviewable:end -->
