### PR TITLE
Exposed method to write project, workspace, schemes and breakpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 - **Breaking:** `XCWorkspace.Data` renamed to `XCWorkspaceData` and removed `references`.
-- Improved README examples
+- Added methods to get paths to workspace, project and breakpoints and shemes files, added public methods to write them separatery.
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 ### Changed
 - **Breaking:** `XCWorkspace.Data` renamed to `XCWorkspaceData` and removed `references`.
-- Added methods to get paths to workspace, project and breakpoints and shemes files, added public methods to write them separatery.
+- Improved README examples. https://github.com/xcodeswift/xcproj/pull/212 by @ilyapuchka
+- Added methods to get paths to workspace, project and breakpoints and shemes files, added public methods to write them separatery. https://github.com/xcodeswift/xcproj/pull/215 by @ilyapuchka
 
 ## 2.0.0
 

--- a/Sources/xcproj/XcodeProj.swift
+++ b/Sources/xcproj/XcodeProj.swift
@@ -58,40 +58,131 @@ final public class XcodeProj {
 
 extension XcodeProj: Writable {
 
+    /// Writes project to the given path.
+    ///
+    /// - Parameter path: path to `.xcodeproj` file.
+    /// - Parameter override: if project should be overridden. Default is true.
+    ///   If false will throw error if project already exists at the given path.
     public func write(path: Path, override: Bool = true) throws {
         try path.mkpath()
         try writeWorkspace(path: path, override: override)
         try writePBXProj(path: path, override: override)
-        try writeSharedData(path: path, override: override)
+        try writeSchemes(path: path, override: override)
+        try writeBreakPoints(path: path, override: override)
     }
 
-    fileprivate func writeWorkspace(path: Path, override: Bool) throws {
-        try workspace.write(path: path + "project.xcworkspace", override: override)
+    /// Returns workspace file path relative to the given path.
+    ///
+    /// - Parameter path: `.xcodeproj` file path
+    /// - Returns: worspace file path relative to the given path.
+    public func workspacePath(_ path: Path) -> Path {
+        return path + "project.xcworkspace"
     }
 
-    fileprivate func writePBXProj(path: Path, override: Bool) throws {
-        try pbxproj.write(path: path + "project.pbxproj", override: override)
+    /// Writes workspace to the given path.
+    ///
+    /// - Parameter path: path to `.xcodeproj` file.
+    /// - Parameter override: if workspace should be overridden. Default is true.
+    ///   If false will throw error if workspace already exists at the given path.
+    public func writeWorkspace(path: Path, override: Bool = true) throws {
+        try workspace.write(path: workspacePath(path), override: override)
     }
 
-    fileprivate func writeSharedData(path: Path, override: Bool) throws {
-        if let sharedData = sharedData {
-            let schemesPath = path + "xcshareddata/xcschemes"
-            if override && schemesPath.exists {
-                try schemesPath.delete()
-            }
-            try schemesPath.mkpath()
-            for scheme in sharedData.schemes {
-                try scheme.write(path: schemesPath + "\(scheme.name).xcscheme", override: override)
-            }
-            let debuggerPath = path + "xcshareddata/xcdebugger"
-            if override && debuggerPath.exists {
-                try debuggerPath.delete()
-            }
-            try debuggerPath.mkpath()
-            try sharedData.breakpoints?.write(path: debuggerPath + "Breakpoints_v2.xcbkptlist", override: override)
+    /// Returns project file path relative to the given path.
+    ///
+    /// - Parameter path: `.xcodeproj` file path
+    /// - Returns: project file path relative to the given path.
+    public func projectPath(_ path: Path) -> Path {
+        return path + "project.pbxproj"
+    }
+
+    /// Writes project to the given path.
+    ///
+    /// - Parameter path: path to `.xcodeproj` file.
+    /// - Parameter override: if project should be overridden. Default is true.
+    ///   If false will throw error if project already exists at the given path.
+    public func writePBXProj(path: Path, override: Bool = true) throws {
+        try pbxproj.write(path: projectPath(path), override: override)
+    }
+
+    /// Returns shared data path relative to the given path.
+    ///
+    /// - Parameter path: `.xcodeproj` file path
+    /// - Returns: shared data path relative to the given path.
+    public func sharedDataPath(_ path: Path) -> Path {
+        return path + "xcshareddata"
+    }
+
+    /// Returns schemes folder path relative to the given path.
+    ///
+    /// - Parameter path: `.xcodeproj` file path
+    /// - Returns: schemes folder path relative to the given path.
+    public func schemesPath(_ path: Path) -> Path {
+        return sharedDataPath(path) + "xcschemes"
+    }
+
+    /// Returns scheme file path relative to the given path.
+    ///
+    /// - Parameter path: `.xcodeproj` file path
+    /// - Parameter schemeName: scheme name
+    /// - Returns: scheme file path relative to the given path.
+    public func schemePath(_ path: Path, schemeName: String) -> Path {
+        return schemesPath(path) + "\(schemeName).xcscheme"
+    }
+
+    /// Writes all project schemes to the given path.
+    ///
+    /// - Parameter path: path to `.xcodeproj` file.
+    /// - Parameter override: if project should be overridden. Default is true.
+    ///   If true will remove all existing schemes before writing.
+    ///   If false will throw error if scheme already exists at the given path.
+    public func writeSchemes(path: Path, override: Bool = true) throws {
+        guard let sharedData = sharedData else { return }
+
+        let schemesPath = self.schemesPath(path)
+        if override && schemesPath.exists {
+            try schemesPath.delete()
+        }
+        try schemesPath.mkpath()
+        for scheme in sharedData.schemes {
+            try scheme.write(path: schemePath(path, schemeName: scheme.name), override: override)
         }
     }
 
+    /// Returns debugger folder path relative to the given path.
+    ///
+    /// - Parameter path: `.xcodeproj` file path
+    /// - Parameter schemeName: scheme name
+    /// - Returns: debugger folder path relative to the given path.
+    public func debuggerPath(_ path: Path) -> Path {
+        return sharedDataPath(path) + "xcdebugger"
+    }
+
+    /// Returns breakpoints plist path relative to the given path.
+    ///
+    /// - Parameter path: `.xcodeproj` file path
+    /// - Parameter schemeName: scheme name
+    /// - Returns: breakpoints plist path relative to the given path.
+    public func breakPointsPath(_ path: Path) -> Path {
+        return debuggerPath(path) + "Breakpoints_v2.xcbkptlist"
+    }
+
+    /// Writes all project breakpoints to the given path.
+    ///
+    /// - Parameter path: path to `.xcodeproj` file.
+    /// - Parameter override: if project should be overridden. Default is true.
+    ///   If true will remove all existing debugger data before writing.
+    ///   If false will throw error if breakpoints file exists at the given path.
+    public func writeBreakPoints(path: Path, override: Bool = true) throws {
+        guard let sharedData = sharedData else { return }
+
+        let debuggerPath = self.debuggerPath(path)
+        if override && debuggerPath.exists {
+            try debuggerPath.delete()
+        }
+        try debuggerPath.mkpath()
+        try sharedData.breakpoints?.write(path: breakPointsPath(path), override: override)
+    }
 }
 
 // MARK: - XcodeProj Extension (Equatable)

--- a/Sources/xcproj/XcodeProj.swift
+++ b/Sources/xcproj/XcodeProj.swift
@@ -75,7 +75,7 @@ extension XcodeProj: Writable {
     ///
     /// - Parameter path: `.xcodeproj` file path
     /// - Returns: worspace file path relative to the given path.
-    public func workspacePath(_ path: Path) -> Path {
+    public static func workspacePath(_ path: Path) -> Path {
         return path + "project.xcworkspace"
     }
 
@@ -85,14 +85,14 @@ extension XcodeProj: Writable {
     /// - Parameter override: if workspace should be overridden. Default is true.
     ///   If false will throw error if workspace already exists at the given path.
     public func writeWorkspace(path: Path, override: Bool = true) throws {
-        try workspace.write(path: workspacePath(path), override: override)
+        try workspace.write(path: XcodeProj.workspacePath(path), override: override)
     }
 
     /// Returns project file path relative to the given path.
     ///
     /// - Parameter path: `.xcodeproj` file path
     /// - Returns: project file path relative to the given path.
-    public func projectPath(_ path: Path) -> Path {
+    public static func pbxprojPath(_ path: Path) -> Path {
         return path + "project.pbxproj"
     }
 
@@ -102,14 +102,14 @@ extension XcodeProj: Writable {
     /// - Parameter override: if project should be overridden. Default is true.
     ///   If false will throw error if project already exists at the given path.
     public func writePBXProj(path: Path, override: Bool = true) throws {
-        try pbxproj.write(path: projectPath(path), override: override)
+        try pbxproj.write(path: XcodeProj.pbxprojPath(path), override: override)
     }
 
     /// Returns shared data path relative to the given path.
     ///
     /// - Parameter path: `.xcodeproj` file path
     /// - Returns: shared data path relative to the given path.
-    public func sharedDataPath(_ path: Path) -> Path {
+    public static func sharedDataPath(_ path: Path) -> Path {
         return path + "xcshareddata"
     }
 
@@ -117,8 +117,8 @@ extension XcodeProj: Writable {
     ///
     /// - Parameter path: `.xcodeproj` file path
     /// - Returns: schemes folder path relative to the given path.
-    public func schemesPath(_ path: Path) -> Path {
-        return sharedDataPath(path) + "xcschemes"
+    public static func schemesPath(_ path: Path) -> Path {
+        return XcodeProj.sharedDataPath(path) + "xcschemes"
     }
 
     /// Returns scheme file path relative to the given path.
@@ -126,8 +126,8 @@ extension XcodeProj: Writable {
     /// - Parameter path: `.xcodeproj` file path
     /// - Parameter schemeName: scheme name
     /// - Returns: scheme file path relative to the given path.
-    public func schemePath(_ path: Path, schemeName: String) -> Path {
-        return schemesPath(path) + "\(schemeName).xcscheme"
+    public static func schemePath(_ path: Path, schemeName: String) -> Path {
+        return XcodeProj.schemesPath(path) + "\(schemeName).xcscheme"
     }
 
     /// Writes all project schemes to the given path.
@@ -139,13 +139,13 @@ extension XcodeProj: Writable {
     public func writeSchemes(path: Path, override: Bool = true) throws {
         guard let sharedData = sharedData else { return }
 
-        let schemesPath = self.schemesPath(path)
+        let schemesPath = XcodeProj.schemesPath(path)
         if override && schemesPath.exists {
             try schemesPath.delete()
         }
         try schemesPath.mkpath()
         for scheme in sharedData.schemes {
-            try scheme.write(path: schemePath(path, schemeName: scheme.name), override: override)
+            try scheme.write(path: XcodeProj.schemePath(path, schemeName: scheme.name), override: override)
         }
     }
 
@@ -154,8 +154,8 @@ extension XcodeProj: Writable {
     /// - Parameter path: `.xcodeproj` file path
     /// - Parameter schemeName: scheme name
     /// - Returns: debugger folder path relative to the given path.
-    public func debuggerPath(_ path: Path) -> Path {
-        return sharedDataPath(path) + "xcdebugger"
+    public static func debuggerPath(_ path: Path) -> Path {
+        return XcodeProj.sharedDataPath(path) + "xcdebugger"
     }
 
     /// Returns breakpoints plist path relative to the given path.
@@ -163,8 +163,8 @@ extension XcodeProj: Writable {
     /// - Parameter path: `.xcodeproj` file path
     /// - Parameter schemeName: scheme name
     /// - Returns: breakpoints plist path relative to the given path.
-    public func breakPointsPath(_ path: Path) -> Path {
-        return debuggerPath(path) + "Breakpoints_v2.xcbkptlist"
+    public static func breakPointsPath(_ path: Path) -> Path {
+        return XcodeProj.debuggerPath(path) + "Breakpoints_v2.xcbkptlist"
     }
 
     /// Writes all project breakpoints to the given path.
@@ -176,12 +176,12 @@ extension XcodeProj: Writable {
     public func writeBreakPoints(path: Path, override: Bool = true) throws {
         guard let sharedData = sharedData else { return }
 
-        let debuggerPath = self.debuggerPath(path)
+        let debuggerPath = XcodeProj.debuggerPath(path)
         if override && debuggerPath.exists {
             try debuggerPath.delete()
         }
         try debuggerPath.mkpath()
-        try sharedData.breakpoints?.write(path: breakPointsPath(path), override: override)
+        try sharedData.breakpoints?.write(path: XcodeProj.breakPointsPath(path), override: override)
     }
 }
 

--- a/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
@@ -71,6 +71,32 @@ final class XcodeProjIntegrationSpec: XCTestCase {
         XCTAssertEqual(output, rawProj)
     }
 
+    // MARK: - Paths
+
+    func test_workspacePath() {
+        let path = fixturesPath() + "iOS/BuildSettings.xcodeproj"
+        XCTAssertEqual(XcodeProj.workspacePath(path),
+                       fixturesPath() + "iOS/BuildSettings.xcodeproj/project.xcworkspace")
+    }
+
+    func test_pbxprojPath() {
+        let path = fixturesPath() + "iOS/BuildSettings.xcodeproj"
+        XCTAssertEqual(XcodeProj.pbxprojPath(path),
+                       fixturesPath() + "iOS/BuildSettings.xcodeproj/project.pbxproj")
+    }
+
+    func test_schemePath() {
+        let path = fixturesPath() + "iOS/BuildSettings.xcodeproj"
+        XCTAssertEqual(XcodeProj.schemePath(path, schemeName: "Scheme"),
+                       fixturesPath() + "iOS/BuildSettings.xcodeproj/xcshareddata/xcschemes/Scheme.xcscheme")
+    }
+
+    func test_breakPointsPath() {
+        let path = fixturesPath() + "iOS/BuildSettings.xcodeproj"
+        XCTAssertEqual(XcodeProj.breakPointsPath(path),
+                       fixturesPath() + "iOS/BuildSettings.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist")
+    }
+
     // MARK: - Private
 
     private func fixtureWithoutWorkspaceProjectPath() -> Path {


### PR DESCRIPTION
### Short description 📝
When writing project with `XcodeProj.write` there is no control over what parts of it will be written, so i.e. workspace and schemes are being overridden when only project changes. Together with #214 it leads to unneeded changes.

### Solution 📦
There are public methods to write scheme, workspace, project etc. but methods used by `XcodeProj.write` provide more functionality and automatically write data in correct paths, when writing project through `pbxproj.write` requires to construct correct path to project file manually. Also added public methods to get those paths to give users more flexibility, i.e. to write individual scheme file instead of overriding all schemes folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/215)
<!-- Reviewable:end -->
