### PR TITLE
Add ObjectReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Changed
+- **Breaking:** Changed the return type of some helper functions that create or fetch PBXObjects to be `ObjectReference`, which includes the reference as well as the object https://github.com/xcodeswift/xcproj/pull/218 by @yonaskolb 
+
 ## 3.0.0
 
 ### Fixed

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		BF1993286802 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR4384942301 /* PBXHeadersBuildPhase.swift */; };
 		BF2033307201 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8483796101 /* PBXFileReference.swift */; };
 		BF2033307202 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR8483796101 /* PBXFileReference.swift */; };
+		BF2203003301 /* ObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5708343501 /* ObjectReference.swift */; };
+		BF2203003302 /* ObjectReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR5708343501 /* ObjectReference.swift */; };
 		BF2241362001 /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6006730201 /* Dictionary+Extras.swift */; };
 		BF2241362002 /* Dictionary+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR6006730201 /* Dictionary+Extras.swift */; };
 		BF2311546501 /* Bool+Extras.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR3255351901 /* Bool+Extras.swift */; };
@@ -165,6 +167,7 @@
 		FR5296652601 /* PBXProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProductType.swift; sourceTree = "<group>"; };
 		FR5395076701 /* XCWorkspaceDataGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataGroup.swift; sourceTree = "<group>"; };
 		FR5460675201 /* PBXCopyFilesBuildPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXCopyFilesBuildPhase.swift; sourceTree = "<group>"; };
+		FR5708343501 /* ObjectReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectReference.swift; sourceTree = "<group>"; };
 		FR6006730201 /* Dictionary+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Dictionary+Extras.swift"; sourceTree = "<group>"; };
 		FR6189630601 /* XCWorkspaceDataFileRef.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceDataFileRef.swift; sourceTree = "<group>"; };
 		FR6357036901 /* KeyedDecodingContainer+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedDecodingContainer+Additions.swift"; sourceTree = "<group>"; };
@@ -267,6 +270,7 @@
 				FR6006730201 /* Dictionary+Extras.swift */,
 				FR8599247801 /* JSONDecoding.swift */,
 				FR6357036901 /* KeyedDecodingContainer+Additions.swift */,
+				FR5708343501 /* ObjectReference.swift */,
 				FR3952162601 /* PBXAggregateTarget.swift */,
 				FR6980748501 /* PBXBuildFile.swift */,
 				FR4128075701 /* PBXBuildPhase.swift */,
@@ -446,6 +450,7 @@
 				BF2241362001 /* Dictionary+Extras.swift in Sources */,
 				BF6518149701 /* JSONDecoding.swift in Sources */,
 				BF1286225401 /* KeyedDecodingContainer+Additions.swift in Sources */,
+				BF2203003301 /* ObjectReference.swift in Sources */,
 				BF3873193301 /* PBXAggregateTarget.swift in Sources */,
 				BF4432284801 /* PBXBuildFile.swift in Sources */,
 				BF6638647201 /* PBXBuildPhase.swift in Sources */,
@@ -510,6 +515,7 @@
 				BF2241362002 /* Dictionary+Extras.swift in Sources */,
 				BF6518149702 /* JSONDecoding.swift in Sources */,
 				BF1286225402 /* KeyedDecodingContainer+Additions.swift in Sources */,
+				BF2203003302 /* ObjectReference.swift in Sources */,
 				BF3873193302 /* PBXAggregateTarget.swift in Sources */,
 				BF4432284802 /* PBXBuildFile.swift in Sources */,
 				BF6638647202 /* PBXBuildPhase.swift in Sources */,

--- a/Sources/xcproj/ObjectReference.swift
+++ b/Sources/xcproj/ObjectReference.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// contains a PBXObject as well as it's reference
+public class ObjectReference<T: PBXObject> {
+
+    public let reference: String
+    public let object: T
+    
+    public init(reference: String, object: T) {
+        self.reference = reference
+        self.object = object
+    }
+}
+
+extension Dictionary where Key == String, Value: PBXObject {
+
+    public var objectReferences: [ObjectReference<Value>] {
+        return self.map(ObjectReference.init)
+    }
+}

--- a/Sources/xcproj/ObjectReference.swift
+++ b/Sources/xcproj/ObjectReference.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// contains a PBXObject as well as it's reference
-public class ObjectReference<T: PBXObject> {
+public class ObjectReference<T: PBXObject>: Equatable {
 
     public let reference: String
     public let object: T
@@ -9,6 +9,12 @@ public class ObjectReference<T: PBXObject> {
     public init(reference: String, object: T) {
         self.reference = reference
         self.object = object
+    }
+
+    public static func == (lhs: ObjectReference,
+                           rhs: ObjectReference) -> Bool {
+        return lhs.reference == rhs.reference &&
+            lhs.object == rhs.object
     }
 }
 

--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element indicates a file reference that is used in a PBXBuildPhase (either as an include or resource).
-final public class PBXBuildFile: PBXObject, Equatable {
+final public class PBXBuildFile: PBXObject {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An absctract class for all the build phase objects
-public class PBXBuildPhase: PBXObject, Equatable {
+public class PBXBuildPhase: PBXObject {
     
     /// Default build action mask.
     public static let defaultBuildActionMask: UInt = 2147483647

--- a/Sources/xcproj/PBXBuildRule.swift
+++ b/Sources/xcproj/PBXBuildRule.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A PBXBuildRule is used to specify a method for transforming an input file in to an output file(s).
-final public class PBXBuildRule: PBXObject, Equatable {
+final public class PBXBuildRule: PBXObject {
 
     // MARK: - Attributes
 

--- a/Sources/xcproj/PBXContainerItemProxy.swift
+++ b/Sources/xcproj/PBXContainerItemProxy.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element to decorate a target item.
-final public class PBXContainerItemProxy: PBXObject, Equatable {
+final public class PBXContainerItemProxy: PBXObject {
 
     public enum ProxyType: UInt, Decodable {
         case nativeTarget = 1

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element is an abstract parent for file and group elements.
-public class PBXFileElement: PBXObject, Equatable, PlistSerializable {
+public class PBXFileElement: PBXObject, PlistSerializable {
     
     // MARK: - Attributes
 

--- a/Sources/xcproj/PBXObject.swift
+++ b/Sources/xcproj/PBXObject.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Class that represents a project element.
-public class PBXObject: Decodable {
+public class PBXObject: Decodable, Equatable {
 
     // MARK: - Init
     
@@ -17,6 +17,11 @@ public class PBXObject: Decodable {
     
     public static var isa: String {
         return String(describing: self)
+    }
+
+    public static func == (lhs: PBXObject,
+                           rhs: PBXObject) -> Bool {
+        return true
     }
 
     //swiftlint:disable function_body_length

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final public class PBXProject: PBXObject, Equatable {
+final public class PBXProject: PBXObject {
     
     // MARK: - Attributes
   

--- a/Sources/xcproj/PBXReferenceProxy.swift
+++ b/Sources/xcproj/PBXReferenceProxy.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A proxy for another object which might belong to another project
 /// contained in the same workspace of the document.
 /// This class is referenced by PBXTargetDependency.
-final public class PBXReferenceProxy: PBXObject, Equatable {
+final public class PBXReferenceProxy: PBXObject {
     
     // MARK: - Attributes
     

--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element is an abstract parent for specialized targets.
-public class PBXTarget: PBXObject, Equatable {
+public class PBXTarget: PBXObject {
 
     /// Target build configuration list.
     public var buildConfigurationList: String?

--- a/Sources/xcproj/PBXTargetDependency.swift
+++ b/Sources/xcproj/PBXTargetDependency.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for referencing other targets through content proxies.
-final public class PBXTargetDependency: PBXObject, Equatable {
+final public class PBXTargetDependency: PBXObject {
     
     // MARK: - Attributes
     

--- a/Sources/xcproj/XCBuildConfiguration.swift
+++ b/Sources/xcproj/XCBuildConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for listing build configurations.
-final public class XCBuildConfiguration: PBXObject, Equatable {
+final public class XCBuildConfiguration: PBXObject {
    
     // MARK: - Attributes
     

--- a/Sources/xcproj/XCConfigurationList.swift
+++ b/Sources/xcproj/XCConfigurationList.swift
@@ -75,10 +75,10 @@ extension XCConfigurationList: PlistSerializable {
     }
     
     private func plistComment(proj: PBXProj, reference: String) -> String? {
-        let object = proj.objects.objectWithConfigurationList(reference: reference)
-        if let project = object as? PBXProject {
+        let objectReference = proj.objects.objectWithConfigurationList(reference: reference)
+        if let project = objectReference?.object as? PBXProject {
             return "Build configuration list for PBXProject \"\(project.name)\""
-        } else if let target = object as? PBXNativeTarget {
+        } else if let target = objectReference?.object as? PBXNativeTarget {
             return "Build configuration list for PBXNativeTarget \"\(target.name)\""
         }
         return nil

--- a/Sources/xcproj/XCConfigurationList.swift
+++ b/Sources/xcproj/XCConfigurationList.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This is the element for listing build configurations.
-final public class XCConfigurationList: PBXObject, Equatable {
+final public class XCConfigurationList: PBXObject {
     
     // MARK: - Attributes
     

--- a/Tests/xcprojTests/PBXProjObjectsHelpersSpec.swift
+++ b/Tests/xcprojTests/PBXProjObjectsHelpersSpec.swift
@@ -19,7 +19,7 @@ final class PBXProjObjectsHelpersSpec: XCTestCase {
         subject.addObject(nativeTarget, reference: "1")
         subject.addObject(legacyTarget, reference: "2")
         subject.addObject(aggregateTarget, reference: "3")
-        let got = subject.targets(named: "test")
+        let got = subject.targets(named: "test").map { $0.object }
         XCTAssertTrue(got.contains(nativeTarget))
         XCTAssertTrue(got.contains(legacyTarget))
         XCTAssertTrue(got.contains(aggregateTarget))


### PR DESCRIPTION
Now that `PBXObject` no longer contains a reference, the helper methods that return a PBXObject are hard to work with as you don't know the reference, for example `targets(named: String) -> PBXTarget`

This can also be evidenced by the new helper functions in #213 that all return a tuple of the reference and the object.

This PR adds a new genenric type `ObjectReference` that contains the reference and the object. This is also used in XcodeGen to ease the migration to the removal of reference from PBXObject

This is actually a breaking change. I was hoping to get this into 3.0 but I didn't know it was releasing early.

Another addition to the `Objects` class that could have also helped is the addition of a `getReference(object: PBXObject) -> String` that would return the reference for a given object using equatable or class identity, but I thought this would be a cleaner approach

This PR also makes `PBXObject` Equatable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/218)
<!-- Reviewable:end -->
