### PR TITLE
Fixes PBXObject equality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## next version
 
 ### Fixed
+- Fixed PBXObject sublasses from checking Equatable properly https://github.com/xcodeswift/xcproj/pull/224 by @yonaskolb
 - Fix Carthage support https://github.com/xcodeswift/xcproj/pull/226 by @ileitch
 
 ### Changed

--- a/Sources/xcproj/PBXBuildFile.swift
+++ b/Sources/xcproj/PBXBuildFile.swift
@@ -41,8 +41,12 @@ final public class PBXBuildFile: PBXObject {
 
     // MARK: - Hashable
 
-    public static func == (lhs: PBXBuildFile,
-                           rhs: PBXBuildFile) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXBuildFile else {
+                return false
+        }
+        let lhs = self
         let settingsAreEqual: Bool = {
             switch (lhs.settings, rhs.settings) {
             case (.none, .none):

--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -45,8 +45,12 @@ public class PBXBuildPhase: PBXObject {
         try super.init(from: decoder)
     }
 
-    public static func == (lhs: PBXBuildPhase,
-                           rhs: PBXBuildPhase) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXBuildPhase else {
+            return false
+        }
+        let lhs = self
         return lhs.files == rhs.files &&
             lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing
     }

--- a/Sources/xcproj/PBXBuildRule.swift
+++ b/Sources/xcproj/PBXBuildRule.swift
@@ -78,8 +78,12 @@ final public class PBXBuildRule: PBXObject {
 
     // MARK: - Equatable
 
-    public static func == (lhs: PBXBuildRule,
-                           rhs: PBXBuildRule) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXBuildRule else {
+                return false
+        }
+        let lhs = self
         let outputFilesCompilerFlagsAreEqual: Bool = {
             switch (lhs.outputFilesCompilerFlags, rhs.outputFilesCompilerFlags) {
                 case (.none, .none):

--- a/Sources/xcproj/PBXContainerItemProxy.swift
+++ b/Sources/xcproj/PBXContainerItemProxy.swift
@@ -39,8 +39,12 @@ final public class PBXContainerItemProxy: PBXObject {
         super.init()
     }
     
-    public static func == (lhs: PBXContainerItemProxy,
-                           rhs: PBXContainerItemProxy) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXContainerItemProxy else {
+                return false
+        }
+        let lhs = self
         return lhs.proxyType == rhs.proxyType &&
             lhs.containerPortal == rhs.containerPortal &&
             lhs.remoteGlobalIDString == rhs.remoteGlobalIDString &&

--- a/Sources/xcproj/PBXCopyFilesBuildPhase.swift
+++ b/Sources/xcproj/PBXCopyFilesBuildPhase.swift
@@ -57,8 +57,12 @@ final public class PBXCopyFilesBuildPhase: PBXBuildPhase {
             runOnlyForDeploymentPostprocessing)
     }
 
-    public static func == (lhs: PBXCopyFilesBuildPhase,
-                           rhs: PBXCopyFilesBuildPhase) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXCopyFilesBuildPhase else {
+                return false
+        }
+        let lhs = self
         return lhs.dstPath == rhs.dstPath &&
             lhs.name == rhs.name &&
             lhs.buildActionMask == rhs.buildActionMask &&

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -30,8 +30,12 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         super.init()
     }
     
-    public static func == (lhs: PBXFileElement,
-                           rhs: PBXFileElement) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXFileElement else {
+                return false
+        }
+        let lhs = self
         return lhs.sourceTree == rhs.sourceTree &&
             lhs.path == rhs.path &&
             lhs.name == rhs.name

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -50,8 +50,12 @@ final public class PBXFileReference: PBXFileElement {
         super.init(sourceTree: sourceTree, path: path, name: name)
     }
 
-    public static func == (lhs: PBXFileReference,
-                           rhs: PBXFileReference) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXFileReference else {
+                return false
+        }
+        let lhs = self
         return lhs.fileEncoding == rhs.fileEncoding &&
             lhs.explicitFileType == rhs.explicitFileType &&
             lhs.lastKnownFileType == rhs.lastKnownFileType &&

--- a/Sources/xcproj/PBXFrameworksBuildPhase.swift
+++ b/Sources/xcproj/PBXFrameworksBuildPhase.swift
@@ -7,8 +7,12 @@ final public class PBXFrameworksBuildPhase: PBXBuildPhase {
         return .frameworks
     }
     
-    public static func == (lhs: PBXFrameworksBuildPhase,
-                           rhs: PBXFrameworksBuildPhase) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXFrameworksBuildPhase else {
+                return false
+        }
+        let lhs = self
         return lhs.files == rhs.files &&
             lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing
     }

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -40,8 +40,12 @@ final public class PBXGroup: PBXFileElement {
         super.init(sourceTree: sourceTree, path: path, name: name)
     }
 
-    public static func == (lhs: PBXGroup,
-                           rhs: PBXGroup) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXGroup else {
+                return false
+        }
+        let lhs = self
         return lhs.children == rhs.children &&
             lhs.name == rhs.name &&
             lhs.sourceTree == rhs.sourceTree &&

--- a/Sources/xcproj/PBXHeadersBuildPhase.swift
+++ b/Sources/xcproj/PBXHeadersBuildPhase.swift
@@ -8,8 +8,12 @@ final public class PBXHeadersBuildPhase: PBXBuildPhase {
         return .headers
     }
 
-    public static func == (lhs: PBXHeadersBuildPhase,
-                           rhs: PBXHeadersBuildPhase) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXHeadersBuildPhase else {
+                return false
+        }
+        let lhs = self
         return lhs.buildActionMask == rhs.buildActionMask &&
             lhs.files == rhs.files &&
             lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing

--- a/Sources/xcproj/PBXLegacyTarget.swift
+++ b/Sources/xcproj/PBXLegacyTarget.swift
@@ -58,8 +58,12 @@ final public class PBXLegacyTarget: PBXTarget {
         try super.init(from: decoder)
     }
     
-    public static func == (lhs: PBXLegacyTarget,
-                           rhs: PBXLegacyTarget) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXLegacyTarget else {
+                return false
+        }
+        let lhs = self
         return (lhs as PBXTarget) == (rhs as PBXTarget) &&
             lhs.buildToolPath == rhs.buildToolPath &&
             lhs.buildArgumentsString == rhs.buildArgumentsString &&

--- a/Sources/xcproj/PBXObject.swift
+++ b/Sources/xcproj/PBXObject.swift
@@ -21,6 +21,10 @@ public class PBXObject: Decodable, Equatable {
 
     public static func == (lhs: PBXObject,
                            rhs: PBXObject) -> Bool {
+        return lhs.isEqual(to: rhs)
+    }
+
+    func isEqual(to object: PBXObject) -> Bool {
         return true
     }
 

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -129,8 +129,12 @@ final public class PBXProject: PBXObject {
     
     // MARK: - Hashable
     
-    public static func == (lhs: PBXProject,
-                           rhs: PBXProject) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXProject else {
+                return false
+        }
+        let lhs = self
         let equalRegion = lhs.developmentRegion == rhs.developmentRegion
         let equalHasScannedForEncodings = lhs.hasScannedForEncodings == rhs.hasScannedForEncodings
         let equalProductRefGroup = lhs.productRefGroup == rhs.productRefGroup

--- a/Sources/xcproj/PBXReferenceProxy.swift
+++ b/Sources/xcproj/PBXReferenceProxy.swift
@@ -52,8 +52,12 @@ final public class PBXReferenceProxy: PBXObject {
     
     // MARK: - Hashable
     
-    public static func == (lhs: PBXReferenceProxy,
-                           rhs: PBXReferenceProxy) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXReferenceProxy else {
+                return false
+        }
+        let lhs = self
         return lhs.fileType == rhs.fileType &&
             lhs.path == rhs.path &&
             lhs.remoteRef == rhs.remoteRef &&

--- a/Sources/xcproj/PBXResourcesBuildPhase.swift
+++ b/Sources/xcproj/PBXResourcesBuildPhase.swift
@@ -7,8 +7,12 @@ final public class PBXResourcesBuildPhase: PBXBuildPhase {
         return .resources
     }
     
-    public static func == (lhs: PBXResourcesBuildPhase,
-                           rhs: PBXResourcesBuildPhase) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXResourcesBuildPhase else {
+                return false
+        }
+        let lhs = self
         return lhs.buildActionMask == rhs.buildActionMask &&
             lhs.files == rhs.files &&
             lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing

--- a/Sources/xcproj/PBXRezBuildPhase.swift
+++ b/Sources/xcproj/PBXRezBuildPhase.swift
@@ -8,8 +8,12 @@ final public class PBXRezBuildPhase: PBXBuildPhase {
         return .carbonResources
     }
 
-    public static func == (lhs: PBXRezBuildPhase,
-                           rhs: PBXRezBuildPhase) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXRezBuildPhase else {
+                return false
+        }
+        let lhs = self
         return lhs.buildActionMask == rhs.buildActionMask &&
             lhs.files == rhs.files &&
             lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing

--- a/Sources/xcproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcproj/PBXShellScriptBuildPhase.swift
@@ -80,8 +80,12 @@ final public class PBXShellScriptBuildPhase: PBXBuildPhase {
         try super.init(from: decoder)
     }
 
-    public static func == (lhs: PBXShellScriptBuildPhase,
-                           rhs: PBXShellScriptBuildPhase) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXShellScriptBuildPhase else {
+                return false
+        }
+        let lhs = self
         return lhs.buildActionMask == rhs.buildActionMask &&
             lhs.files == rhs.files &&
             lhs.name == rhs.name &&

--- a/Sources/xcproj/PBXSourcesBuildPhase.swift
+++ b/Sources/xcproj/PBXSourcesBuildPhase.swift
@@ -9,8 +9,12 @@ final public class PBXSourcesBuildPhase: PBXBuildPhase {
 
     // MARK: - Hashable
     
-    public static func == (lhs: PBXSourcesBuildPhase,
-                           rhs: PBXSourcesBuildPhase) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXSourcesBuildPhase else {
+                return false
+        }
+        let lhs = self
         return lhs.buildActionMask == rhs.buildActionMask &&
         lhs.files == rhs.files &&
         lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing

--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -72,8 +72,12 @@ public class PBXTarget: PBXObject {
         try super.init(from: decoder)
     }
 
-    public static func == (lhs: PBXTarget,
-                           rhs: PBXTarget) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXTarget else {
+                return false
+        }
+        let lhs = self
         return lhs.buildConfigurationList == rhs.buildConfigurationList &&
             lhs.buildPhases == rhs.buildPhases &&
             lhs.buildRules == rhs.buildRules &&

--- a/Sources/xcproj/PBXTargetDependency.swift
+++ b/Sources/xcproj/PBXTargetDependency.swift
@@ -27,8 +27,12 @@ final public class PBXTargetDependency: PBXObject {
     
     // MARK: - Hashable
     
-    public static func == (lhs: PBXTargetDependency,
-                           rhs: PBXTargetDependency) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXTargetDependency else {
+                return false
+        }
+        let lhs = self
         return lhs.target == rhs.target &&
         lhs.targetProxy == rhs.targetProxy
     }

--- a/Sources/xcproj/PBXVariantGroup.swift
+++ b/Sources/xcproj/PBXVariantGroup.swift
@@ -40,8 +40,12 @@ final public class PBXVariantGroup: PBXFileElement {
 
     // MARK: - Hashable
 
-    public static func == (lhs: PBXVariantGroup,
-                           rhs: PBXVariantGroup) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? PBXVariantGroup else {
+                return false
+        }
+        let lhs = self
         return lhs.children == rhs.children &&
         lhs.name == rhs.name &&
         lhs.sourceTree == rhs.sourceTree

--- a/Sources/xcproj/XCBuildConfiguration.swift
+++ b/Sources/xcproj/XCBuildConfiguration.swift
@@ -31,8 +31,12 @@ final public class XCBuildConfiguration: PBXObject {
         super.init()
     }
     
-    public static func == (lhs: XCBuildConfiguration,
-                           rhs: XCBuildConfiguration) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? XCBuildConfiguration else {
+                return false
+        }
+        let lhs = self
         return lhs.baseConfigurationReference == rhs.baseConfigurationReference &&
             lhs.name == rhs.name &&
             NSDictionary(dictionary: lhs.buildSettings).isEqual(to: rhs.buildSettings)

--- a/Sources/xcproj/XCConfigurationList.swift
+++ b/Sources/xcproj/XCConfigurationList.swift
@@ -31,8 +31,12 @@ final public class XCConfigurationList: PBXObject {
         super.init()
     }
 
-    public static func == (lhs: XCConfigurationList,
-                           rhs: XCConfigurationList) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? XCConfigurationList else {
+                return false
+        }
+        let lhs = self
         return lhs.buildConfigurations == rhs.buildConfigurations &&
             lhs.defaultConfigurationIsVisible == rhs.defaultConfigurationIsVisible
     }

--- a/Sources/xcproj/XCVersionGroup.swift
+++ b/Sources/xcproj/XCVersionGroup.swift
@@ -30,8 +30,12 @@ final public class XCVersionGroup: PBXFileElement {
         super.init(sourceTree: sourceTree, path: path, name: name)
     }
 
-    public static func == (lhs: XCVersionGroup,
-                           rhs: XCVersionGroup) -> Bool {
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: self),
+            let rhs = object as? XCVersionGroup else {
+                return false
+        }
+        let lhs = self
         return lhs.currentVersion == rhs.currentVersion &&
         lhs.versionGroupType == rhs.versionGroupType &&
         lhs.children == rhs.children

--- a/Tests/xcprojTests/PBXRezBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXRezBuildPhaseSpec.swift
@@ -22,7 +22,7 @@ final class PBXRezBuildPhaseSpec: XCTestCase {
     }
 
     func test_equals_returnsTheCorrectValue() {
-        let another = PBXResourcesBuildPhase(files: ["123"],
+        let another = PBXRezBuildPhase(files: ["123"],
                                              runOnlyForDeploymentPostprocessing: false)
         XCTAssertEqual(subject, another)
     }


### PR DESCRIPTION
Resolves #223

This makes PBXObject conform to `Equatable` which then calls out to an instance method that all subclasses override. When we move to Sourcery we can remove all of this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/224)
<!-- Reviewable:end -->
