### PR TITLE
Add support for environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## next version
 
-#### Added
+### Added
 - Added `tvOS` and `watchOS` Carthage support https://github.com/xcodeswift/xcproj/pull/232 by @yonaskolb
+- Added support for scheme environment variables https://github.com/xcodeswift/xcproj/pull/227 by @turekj
 
 ### Fixed
 - Fixed PBXObject sublasses from checking Equatable properly https://github.com/xcodeswift/xcproj/pull/224 by @yonaskolb

--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -44,6 +44,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <PreActions>
          <ExecutionAction
@@ -98,16 +99,27 @@
             ReferencedContainer = "container:Project.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "MyTestArgument"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "ENV_VAR"
+            value = "TEST"
+            isEnabled = "NO">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
-      <CommandLineArguments>
-        <CommandLineArgument argument="MyTestArgument" isEnabled="YES"></CommandLineArgument>
-      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -160,15 +172,25 @@
             ReferencedContainer = "container:Project.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "MyLaunchArgument"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "ENV_VAR"
+            value = "RUN"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
       <LocationScenarioReference
          identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
          referenceType = "1">
       </LocationScenarioReference>
-      <CommandLineArguments>
-        <CommandLineArgument argument="MyLaunchArgument" isEnabled="YES"></CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -196,8 +218,18 @@
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
-        <CommandLineArgument argument="MyProfileArgument" isEnabled="NO"></CommandLineArgument>
+         <CommandLineArgument
+            argument = "MyProfileArgument"
+            isEnabled = "NO">
+         </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "ENV_VAR"
+            value = "PROFILE"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Sources/xcproj/AEXML+XcodeFormat.swift
+++ b/Sources/xcproj/AEXML+XcodeFormat.swift
@@ -60,6 +60,11 @@ let attributesOrder: [String: [String]] = [
     "ActionContent": [
         "title",
         "scriptText"
+    ],
+    "EnvironmentVariable": [
+        "key",
+        "value",
+        "isEnabled"
     ]
 ]
 

--- a/Sources/xcproj/XCScheme.swift
+++ b/Sources/xcproj/XCScheme.swift
@@ -174,6 +174,12 @@ final public class XCScheme {
         public let value: String
         public let enabled: Bool
 
+        public init(variable: String, value: String, enabled: Bool) {
+            self.variable = variable
+            self.value = value
+            self.enabled = enabled
+        }
+
         fileprivate func xmlElement() -> AEXMLElement {
             return AEXMLElement(name: "EnvironmentVariable",
                                 value: nil,

--- a/Sources/xcproj/XCScheme.swift
+++ b/Sources/xcproj/XCScheme.swift
@@ -512,6 +512,11 @@ final public class XCScheme {
                 element.addChild(locationScenarioReference.xmlElement())
             }
 
+            if let macroExpansion = macroExpansion {
+                let macro = element.addChild(name: "MacroExpansion")
+                macro.addChild(macroExpansion.xmlElement())
+            }
+
             if let commandlineArguments = commandlineArguments {
                 element.addChild(commandlineArguments.xmlElement())
             }
@@ -522,11 +527,6 @@ final public class XCScheme {
 
             if let region = region {
                 element.attributes["region"] = region
-            }
-
-            if let macroExpansion = macroExpansion {
-                let macro = element.addChild(name: "MacroExpansion")
-                macro.addChild(macroExpansion.xmlElement())
             }
 
             element.addChild(AEXMLElement(name: "AdditionalOptions"))

--- a/Tests/xcprojTests/XCSchemeSpec.swift
+++ b/Tests/xcprojTests/XCSchemeSpec.swift
@@ -86,6 +86,12 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.testAction?.macroExpansion?.referencedContainer, "container:Project.xcodeproj")
         XCTAssertEqual(scheme.testAction?.macroExpansion?.referencedContainer, "container:Project.xcodeproj")
 
+        let testEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.testAction?.environmentVariables)
+        XCTAssertEqual(testEnvironmentVariables.variables.count, 1)
+        XCTAssertEqual(testEnvironmentVariables.variables[0].key, "ENV_VAR")
+        XCTAssertEqual(testEnvironmentVariables.variables[0].value, "TEST")
+        XCTAssertFalse(testEnvironmentVariables.variables[0].enabled)
+
         let testCLIArgs = XCTAssertNotNilAndUnwrap(scheme.testAction?.commandlineArguments)
         XCTAssertTrue(testCLIArgs.arguments.count > 0)
         XCTAssertEqual(testCLIArgs.arguments[0].name, "MyTestArgument")
@@ -117,6 +123,12 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.profileAction?.preActions.isEmpty, true)
         XCTAssertEqual(scheme.profileAction?.postActions.first?.title, "Run Script")
         XCTAssertEqual(scheme.profileAction?.postActions.first?.scriptText, "echo analysis done")
+
+        let profileEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.profileAction?.environmentVariables)
+        XCTAssertEqual(profileEnvironmentVariables.variables.count, 1)
+        XCTAssertEqual(profileEnvironmentVariables.variables[0].key, "ENV_VAR")
+        XCTAssertEqual(profileEnvironmentVariables.variables[0].value, "PROFILE")
+        XCTAssertTrue(profileEnvironmentVariables.variables[0].enabled)
 
         let profileCLIArgs = XCTAssertNotNilAndUnwrap(scheme.profileAction?.commandlineArguments)
         XCTAssertTrue(profileCLIArgs.arguments.count > 0)
@@ -156,6 +168,12 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.postActions.first?.environmentBuildable?.blueprintName, "iOSTests")
         XCTAssertEqual(scheme.launchAction?.postActions.first?.environmentBuildable?.referencedContainer, "container:Project.xcodeproj")
 
+        let launchEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.launchAction?.environmentVariables)
+        XCTAssertEqual(launchEnvironmentVariables.variables.count, 1)
+        XCTAssertEqual(launchEnvironmentVariables.variables[0].key, "ENV_VAR")
+        XCTAssertEqual(launchEnvironmentVariables.variables[0].value, "RUN")
+        XCTAssertTrue(launchEnvironmentVariables.variables[0].enabled)
+
         let launchCLIArgs = XCTAssertNotNilAndUnwrap(scheme.launchAction?.commandlineArguments)
         XCTAssertTrue(launchCLIArgs.arguments.count > 0)
         XCTAssertEqual(launchCLIArgs.arguments[0].name, "MyLaunchArgument")
@@ -189,6 +207,7 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertTrue(scheme.testAction?.codeCoverageEnabled == false)
         XCTAssertNil(scheme.testAction?.macroExpansion)
         XCTAssertNil(scheme.testAction?.commandlineArguments)
+        XCTAssertNil(scheme.testAction?.environmentVariables)
 
         // Launch action
         XCTAssertNil(scheme.launchAction?.buildableProductRunnable)
@@ -204,6 +223,12 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertNil(scheme.launchAction?.locationScenarioReference)
         XCTAssertNil(scheme.launchAction?.commandlineArguments)
 
+        let launchEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.launchAction?.environmentVariables)
+        XCTAssertEqual(launchEnvironmentVariables.variables.count, 1)
+        XCTAssertEqual(launchEnvironmentVariables.variables[0].key, "AI_TEST_MODE")
+        XCTAssertEqual(launchEnvironmentVariables.variables[0].value, "integration")
+        XCTAssertTrue(launchEnvironmentVariables.variables[0].enabled)
+
         // Profile action
         XCTAssertNil(scheme.profileAction?.buildableProductRunnable)
         XCTAssertEqual(scheme.profileAction?.buildConfiguration, "Release")
@@ -212,6 +237,7 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertTrue(scheme.profileAction?.useCustomWorkingDirectory == false)
         XCTAssertTrue(scheme.profileAction?.debugDocumentVersioning == true)
         XCTAssertNil(scheme.profileAction?.commandlineArguments)
+        XCTAssertNil(scheme.profileAction?.environmentVariables)
 
         // Analzye action
         XCTAssertEqual(scheme.analyzeAction?.buildConfiguration, "Debug")

--- a/Tests/xcprojTests/XCSchemeSpec.swift
+++ b/Tests/xcprojTests/XCSchemeSpec.swift
@@ -87,10 +87,10 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.testAction?.macroExpansion?.referencedContainer, "container:Project.xcodeproj")
 
         let testEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.testAction?.environmentVariables)
-        XCTAssertEqual(testEnvironmentVariables.variables.count, 1)
-        XCTAssertEqual(testEnvironmentVariables.variables[0].key, "ENV_VAR")
-        XCTAssertEqual(testEnvironmentVariables.variables[0].value, "TEST")
-        XCTAssertFalse(testEnvironmentVariables.variables[0].enabled)
+        XCTAssertEqual(testEnvironmentVariables.count, 1)
+        XCTAssertEqual(testEnvironmentVariables[0].variable, "ENV_VAR")
+        XCTAssertEqual(testEnvironmentVariables[0].value, "TEST")
+        XCTAssertFalse(testEnvironmentVariables[0].enabled)
 
         let testCLIArgs = XCTAssertNotNilAndUnwrap(scheme.testAction?.commandlineArguments)
         XCTAssertTrue(testCLIArgs.arguments.count > 0)
@@ -125,10 +125,10 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.profileAction?.postActions.first?.scriptText, "echo analysis done")
 
         let profileEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.profileAction?.environmentVariables)
-        XCTAssertEqual(profileEnvironmentVariables.variables.count, 1)
-        XCTAssertEqual(profileEnvironmentVariables.variables[0].key, "ENV_VAR")
-        XCTAssertEqual(profileEnvironmentVariables.variables[0].value, "PROFILE")
-        XCTAssertTrue(profileEnvironmentVariables.variables[0].enabled)
+        XCTAssertEqual(profileEnvironmentVariables.count, 1)
+        XCTAssertEqual(profileEnvironmentVariables[0].variable, "ENV_VAR")
+        XCTAssertEqual(profileEnvironmentVariables[0].value, "PROFILE")
+        XCTAssertTrue(profileEnvironmentVariables[0].enabled)
 
         let profileCLIArgs = XCTAssertNotNilAndUnwrap(scheme.profileAction?.commandlineArguments)
         XCTAssertTrue(profileCLIArgs.arguments.count > 0)
@@ -169,10 +169,10 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertEqual(scheme.launchAction?.postActions.first?.environmentBuildable?.referencedContainer, "container:Project.xcodeproj")
 
         let launchEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.launchAction?.environmentVariables)
-        XCTAssertEqual(launchEnvironmentVariables.variables.count, 1)
-        XCTAssertEqual(launchEnvironmentVariables.variables[0].key, "ENV_VAR")
-        XCTAssertEqual(launchEnvironmentVariables.variables[0].value, "RUN")
-        XCTAssertTrue(launchEnvironmentVariables.variables[0].enabled)
+        XCTAssertEqual(launchEnvironmentVariables.count, 1)
+        XCTAssertEqual(launchEnvironmentVariables[0].variable, "ENV_VAR")
+        XCTAssertEqual(launchEnvironmentVariables[0].value, "RUN")
+        XCTAssertTrue(launchEnvironmentVariables[0].enabled)
 
         let launchCLIArgs = XCTAssertNotNilAndUnwrap(scheme.launchAction?.commandlineArguments)
         XCTAssertTrue(launchCLIArgs.arguments.count > 0)
@@ -224,10 +224,10 @@ final class XCSchemeIntegrationSpec: XCTestCase {
         XCTAssertNil(scheme.launchAction?.commandlineArguments)
 
         let launchEnvironmentVariables = XCTAssertNotNilAndUnwrap(scheme.launchAction?.environmentVariables)
-        XCTAssertEqual(launchEnvironmentVariables.variables.count, 1)
-        XCTAssertEqual(launchEnvironmentVariables.variables[0].key, "AI_TEST_MODE")
-        XCTAssertEqual(launchEnvironmentVariables.variables[0].value, "integration")
-        XCTAssertTrue(launchEnvironmentVariables.variables[0].enabled)
+        XCTAssertEqual(launchEnvironmentVariables.count, 1)
+        XCTAssertEqual(launchEnvironmentVariables[0].variable, "AI_TEST_MODE")
+        XCTAssertEqual(launchEnvironmentVariables[0].value, "integration")
+        XCTAssertTrue(launchEnvironmentVariables[0].enabled)
 
         // Profile action
         XCTAssertNil(scheme.profileAction?.buildableProductRunnable)


### PR DESCRIPTION
Adds support for environment variables in Xcode schemes. Example usage: snapshot tests (see: [iOSSnapshotTestCase](https://github.com/uber/ios-snapshot-test-case).

This is a base needed to implement [XcodeGen's #236](https://github.com/yonaskolb/XcodeGen/issues/236).

I have seen that integration tests are failing, but going through the diff I think it was not caused by this PR. Also, it improves Eigen integration test case.

Let me know if it's any good for you! 👍

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/227)
<!-- Reviewable:end -->
