### PR TITLE
Fix adding PBXGroup without folder reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed PBXObject sublasses from checking Equatable properly https://github.com/xcodeswift/xcproj/pull/224 by @yonaskolb
 - Fix Carthage support https://github.com/xcodeswift/xcproj/pull/226 by @ileitch
 - Fix adding file reference to bundle and package files https://github.com/xcodeswift/xcproj/pull/234 by @fuzza
+- Fix adding PBXGroup without folder reference https://github.com/xcodeswift/xcproj/pull/235 by @fuzza
 
 ### Changed
 - Carthage minimum Deployment Target https://github.com/xcodeswift/xcproj/pull/229 by @olbrichj

--- a/Sources/xcproj/PBXProjObjects+Helpers.swift
+++ b/Sources/xcproj/PBXProjObjects+Helpers.swift
@@ -196,7 +196,7 @@ public struct GroupAddingOptions: OptionSet {
         self.rawValue = rawValue
     }
     /// Create group without reference to folder
-    static let withoutFolder    = GroupAddingOptions(rawValue: 1 << 0)
+    public static let withoutFolder = GroupAddingOptions(rawValue: 1 << 0)
 }
 
 public enum XCodeProjEditingError: Error, CustomStringConvertible {

--- a/Tests/xcprojTests/PBXProj+XCTest.swift
+++ b/Tests/xcprojTests/PBXProj+XCTest.swift
@@ -1,0 +1,9 @@
+import Foundation
+@testable import xcproj
+
+extension PBXProj {
+    func encode() -> String {
+        let encoder = PBXProjEncoder()
+        return encoder.encode(proj: self)
+    }
+}


### PR DESCRIPTION
### Short description 📝
Resolves https://github.com/xcodeswift/xcproj/issues/231

### Solution 📦
Make `GroupAddingOptions.withoutFolder` public.

### Implementation 👩‍💻👨‍💻
- [x] Make `GroupAddingOptions.withoutFolder` public
- [x]  Run XcodeProjIntegrationSpec over public API of PBXProj (remove
  @testable import)
- [x] Move internal API usage from integration spec to PBXProj+XCTest helper
- [x] Restructure and add test cases for PBXGroup
- [x] Update changelog

### GIF
![gif]()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/235)
<!-- Reviewable:end -->
