### PR TITLE
Fix PBXLegacyTarget Equatable

### DIFF
--- a/Sources/xcproj/PBXLegacyTarget.swift
+++ b/Sources/xcproj/PBXLegacyTarget.swift
@@ -64,8 +64,7 @@ final public class PBXLegacyTarget: PBXTarget {
                 return false
         }
         let lhs = self
-        return (lhs as PBXTarget) == (rhs as PBXTarget) &&
-            lhs.buildToolPath == rhs.buildToolPath &&
+        return lhs.buildToolPath == rhs.buildToolPath &&
             lhs.buildArgumentsString == rhs.buildArgumentsString &&
             lhs.passBuildSettingsInEnvironment == rhs.passBuildSettingsInEnvironment &&
             lhs.buildWorkingDirectory == rhs.buildWorkingDirectory


### PR DESCRIPTION
This fixes a regression in #224 where checking PBXLegacyTarget equitability was leading to infinite recursion

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/237)
<!-- Reviewable:end -->
