### PR TITLE
Load Xcode Project-Relative XCConfig Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Changed
+- Support for `XCConfig` project-relative includes https://github.com/xcodeswift/xcproj/pull/238 by @briantkelley
+
 ## 4.1.0
 
 ### Added


### PR DESCRIPTION
### Short description 📝
If an xcconfig file includes another xcconfig file with a relative path, Xcode will first attempt to load the included file relative to the including xcconfig's path. If that fails, Xcode will attempt to load the included xcconfig file relative to the Xcode project.

### Solution 📦
Add the Xcode Project Path as an optional parameter to the XCConfig initializer, so we can use that to resolve the include's relative path.

I went with making it an optional parameter instead of required to maintain source compatibility and to de-empahasize this less used feature. Open to making it required, however.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/238)
<!-- Reviewable:end -->
