### PR TITLE
Fix Writing of showEnvVarsInLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - `PBXObject.isEqual(to:)` overrides correctly call super https://github.com/xcodeswift/xcproj/pull/239 by @briantkelley
 - `PBXAggregateTarget` does not write `buildRules` https://github.com/xcodeswift/xcproj/pull/241 by @briantkelley
+- Writes showEnvVarsInLog only when false https://github.com/xcodeswift/xcproj/pull/240 by @briantkelley
 
 ## 4.1.0
 

--- a/Sources/xcproj/PBXShellScriptBuildPhase.swift
+++ b/Sources/xcproj/PBXShellScriptBuildPhase.swift
@@ -46,7 +46,7 @@ final public class PBXShellScriptBuildPhase: PBXBuildPhase {
                 shellScript: String? = nil,
                 buildActionMask: UInt = defaultBuildActionMask,
                 runOnlyForDeploymentPostprocessing: Bool = false,
-                showEnvVarsInLog: Bool = false) {
+                showEnvVarsInLog: Bool = true) {
         self.name = name
         self.inputPaths = inputPaths
         self.outputPaths = outputPaths
@@ -76,7 +76,7 @@ final public class PBXShellScriptBuildPhase: PBXBuildPhase {
         self.outputPaths = (try container.decodeIfPresent(.outputPaths)) ?? []
         self.shellPath = try container.decodeIfPresent(.shellPath)
         self.shellScript = try container.decodeIfPresent(.shellScript)
-        self.showEnvVarsInLog = try container.decodeIntBool(.showEnvVarsInLog)
+        self.showEnvVarsInLog = try container.decodeIntBoolIfPresent(.showEnvVarsInLog) ?? true
         try super.init(from: decoder)
     }
 
@@ -117,7 +117,10 @@ extension PBXShellScriptBuildPhase: PlistSerializable {
         if let shellScript = shellScript {
             dictionary["shellScript"] = .string(CommentedString(shellScript))
         }
-        dictionary["showEnvVarsInLog"] = .string(CommentedString("\(showEnvVarsInLog.int)"))
+        if !showEnvVarsInLog {
+            // Xcode only writes this key if it's set to false; default is true and is omitted
+            dictionary["showEnvVarsInLog"] = .string(CommentedString("\(showEnvVarsInLog.int)"))
+        }
         return (key: CommentedString(reference, comment: self.name ?? "ShellScript"), value: .dictionary(dictionary))
     }
 

--- a/Tests/xcprojTests/PBXShellScriptBuildPhaseSpec.swift
+++ b/Tests/xcprojTests/PBXShellScriptBuildPhaseSpec.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import xcproj
+@testable import xcproj
 
 final class PBXShellScriptBuildPhaseSpec: XCTestCase {
 
@@ -28,6 +28,28 @@ final class PBXShellScriptBuildPhaseSpec: XCTestCase {
         let one = PBXShellScriptBuildPhase(files: ["file"], name: "name", inputPaths: ["input"], outputPaths: ["output"], shellPath: "shell", shellScript: "script")
         let another = PBXShellScriptBuildPhase(files: ["file"], name: "name", inputPaths: ["input"], outputPaths: ["output"], shellPath: "shell", shellScript: "script")
         XCTAssertEqual(one, another)
+    }
+
+    func test_write_showEnvVarsInLog() {
+        let show = PBXShellScriptBuildPhase(showEnvVarsInLog: true)
+        let doNotShow = PBXShellScriptBuildPhase(showEnvVarsInLog: false)
+
+        let proj = PBXProj(rootObject: "rootObject",
+                objectVersion: 48,
+                objects: ["show": show,
+                          "doNotShow": doNotShow])
+
+        let (_, showPlistValue) = show.plistKeyAndValue(proj: proj, reference: "ref")
+        let (_, doNotShowPlistValue) = doNotShow.plistKeyAndValue(proj: proj, reference: "ref")
+
+        if case PlistValue.dictionary(let showDictionary) = showPlistValue,
+            case PlistValue.dictionary(let doNotShowDictionary) = doNotShowPlistValue {
+
+            XCTAssertNil(showDictionary["showEnvVarsInLog"])
+            XCTAssertEqual(doNotShowDictionary["showEnvVarsInLog"]?.string, "0")
+        } else {
+            XCTAssert(false)
+        }
     }
 
     private func testDictionary() -> [String: Any] {


### PR DESCRIPTION
### Short description 📝
Xcode writes showEnvVarsInLog to the pbxproj file if it’s set to false. If it’s true, it’s omitted.

### Solution 📦
Update xcproj to use the same behavior as Xcode to eliminate diffs when round tripping Xcode projects.

This requires defaulting to true when decoding the project file if the key is omitted. I also updated the default parameter in the initializer to true for good measure.

### Implementation 👩‍💻👨‍💻
- [x] Verify "Show environment variables in build log" is true when creating a new Run Script build phase
- [x] Verify Xcode writes the flag when false but never when true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/240)
<!-- Reviewable:end -->
