### PR TITLE
Add PBXTarget Related Properties and Diff Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## next version
 
+### Added
+- `PBXNativeTarget.productInstallPath`, `PBXTargetDependency.name` https://github.com/xcodeswift/xcproj/pull/241 by @briantkelley
+
 ### Changed
 - Support for `XCConfig` project-relative includes https://github.com/xcodeswift/xcproj/pull/238 by @briantkelley
 
 ### Fixed
 - `PBXObject.isEqual(to:)` overrides correctly call super https://github.com/xcodeswift/xcproj/pull/239 by @briantkelley
+- `PBXAggregateTarget` does not write `buildRules` https://github.com/xcodeswift/xcproj/pull/241 by @briantkelley
 
 ## 4.1.0
 

--- a/Sources/xcproj/PBXNativeTarget.swift
+++ b/Sources/xcproj/PBXNativeTarget.swift
@@ -3,6 +3,61 @@ import Foundation
 /// This is the element for a build target that produces a binary content (application or library).
 final public class PBXNativeTarget: PBXTarget {
 
+    // Target product install path.
+    public var productInstallPath: String?
+
+    public init(name: String,
+                buildConfigurationList: String? = nil,
+                buildPhases: [String] = [],
+                buildRules: [String] = [],
+                dependencies: [String] = [],
+                productInstallPath: String? = nil,
+                productName: String? = nil,
+                productReference: String? = nil,
+                productType: PBXProductType? = nil) {
+        self.productInstallPath = productInstallPath
+        super.init(name: name,
+                   buildConfigurationList: buildConfigurationList,
+                   buildPhases: buildPhases,
+                   buildRules: buildRules,
+                   dependencies: dependencies,
+                   productName: productName,
+                   productReference: productReference,
+                   productType: productType)
+    }
+
+    // MARK: - Decodable
+
+    fileprivate enum CodingKeys: String, CodingKey {
+        case productInstallPath
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.productInstallPath = try container.decodeIfPresent(.productInstallPath)
+        try super.init(from: decoder)
+    }
+
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard let rhs = object as? PBXNativeTarget,
+            super.isEqual(to: rhs) else {
+                return false
+        }
+        let lhs = self
+        return lhs.productInstallPath == rhs.productInstallPath
+    }
+
+    override func plistValues(proj: PBXProj, isa: String, reference: String) -> (key: CommentedString, value: PlistValue) {
+        let (key, value) = super.plistValues(proj: proj, isa: isa, reference: reference)
+        guard case PlistValue.dictionary(var dict) = value else {
+            fatalError("Expected super to give a dictionary")
+        }
+        if let productInstallPath = productInstallPath {
+            dict["productInstallPath"] = .string(CommentedString(productInstallPath))
+        }
+        return (key: key, value: .dictionary(dict))
+    }
+
 }
 
 // MARK: - PBXNativeTarget Extension (PlistSerializable)

--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -100,8 +100,8 @@ public class PBXTarget: PBXObject {
                 return .string(CommentedString(buildPhase, comment: comment))
         })
 
-        // Xcode doesn't write empty PBXLegacyTarget buildRules
-        if !(self is PBXLegacyTarget) || !buildRules.isEmpty {
+        // Xcode doesn't write PBXAggregateTarget buildRules or empty PBXLegacyTarget buildRules
+        if !(self is PBXAggregateTarget), !(self is PBXLegacyTarget) || !buildRules.isEmpty {
             dictionary["buildRules"] = .array(buildRules.map {.string(CommentedString($0))})
         }
         

--- a/Sources/xcproj/PBXTargetDependency.swift
+++ b/Sources/xcproj/PBXTargetDependency.swift
@@ -5,6 +5,9 @@ final public class PBXTargetDependency: PBXObject {
     
     // MARK: - Attributes
     
+    /// Target name.
+    public var name: String?
+
     /// Target reference.
     public var target: String?
     
@@ -16,10 +19,13 @@ final public class PBXTargetDependency: PBXObject {
     /// Initializes the target dependency.
     ///
     /// - Parameters:
+    ///   - name: element name.
     ///   - target: element target.
     ///   - targetProxy: element target proxy.
-    public init(target: String? = nil,
+    public init(name: String? = nil,
+                target: String? = nil,
                 targetProxy: String? = nil) {
+        self.name = name
         self.target = target
         self.targetProxy = targetProxy
         super.init()
@@ -33,19 +39,22 @@ final public class PBXTargetDependency: PBXObject {
                 return false
         }
         let lhs = self
-        return lhs.target == rhs.target &&
-        lhs.targetProxy == rhs.targetProxy
+        return lhs.name == rhs.name &&
+            lhs.target == rhs.target &&
+            lhs.targetProxy == rhs.targetProxy
     }
     
     // MARK: - Decodable
     
     fileprivate enum CodingKeys: String, CodingKey {
+        case name
         case target
         case targetProxy
     }
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decodeIfPresent(.name)
         self.target = try container.decodeIfPresent(.target)
         self.targetProxy = try container.decodeIfPresent(.targetProxy)
         try super.init(from: decoder)
@@ -60,6 +69,9 @@ extension PBXTargetDependency: PlistSerializable {
     func plistKeyAndValue(proj: PBXProj, reference: String) -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = [:]
         dictionary["isa"] = .string(CommentedString(PBXTargetDependency.isa))
+        if let name = name {
+            dictionary["name"] = .string(CommentedString(name))
+        }
         if let target = target {
             let targetName = proj.objects.getTarget(reference: target)?.name
             dictionary["target"] = .string(CommentedString(target, comment: targetName))

--- a/Tests/xcprojTests/PBXNativeTargetSpec.swift
+++ b/Tests/xcprojTests/PBXNativeTargetSpec.swift
@@ -13,6 +13,7 @@ final class PBXNativeTargetSpec: XCTestCase {
                                   buildPhases: ["phase"],
                                   buildRules: ["rule"],
                                   dependencies: ["dependency"],
+                                  productInstallPath: "/usr/local/bin",
                                   productName: "productname",
                                   productReference: "productreference",
                                   productType: .application)
@@ -28,6 +29,7 @@ final class PBXNativeTargetSpec: XCTestCase {
         XCTAssertEqual(subject.buildRules, ["rule"])
         XCTAssertEqual(subject.dependencies, ["dependency"])
         XCTAssertEqual(subject.name, "name")
+        XCTAssertEqual(subject.productInstallPath, "/usr/local/bin")
         XCTAssertEqual(subject.productName, "productname")
         XCTAssertEqual(subject.productReference, "productreference")
         XCTAssertEqual(subject.productType, .application)
@@ -50,6 +52,7 @@ final class PBXNativeTargetSpec: XCTestCase {
                                       buildPhases: ["phase"],
                                       buildRules: ["rule"],
                                       dependencies: ["dependency"],
+                                      productInstallPath: "/usr/local/bin",
                                       productName: "productname",
                                       productReference: "productreference",
                                       productType: .application)
@@ -62,7 +65,8 @@ final class PBXNativeTargetSpec: XCTestCase {
             "buildPhases": ["phase"],
             "buildRules": ["rule"],
             "dependencies": ["dependency"],
-            "name": "name"
+            "name": "name",
+            "productInstallPath": "/usr/local/bin"
         ]
     }
 

--- a/Tests/xcprojTests/PBXTargetDependencySpec.swift
+++ b/Tests/xcprojTests/PBXTargetDependencySpec.swift
@@ -7,11 +7,13 @@ final class PBXTargetDependencySpec: XCTestCase {
     var subject: PBXTargetDependency!
 
     override func setUp() {
-        subject = PBXTargetDependency(target: "target",
+        subject = PBXTargetDependency(name: "name",
+                                      target: "target",
                                       targetProxy: "target_proxy")
     }
 
     func test_init_initializesTheTargetDependencyWithTheCorrectAttributes() {
+        XCTAssertEqual(subject.name, "name")
         XCTAssertEqual(subject.target, "target")
         XCTAssertEqual(subject.targetProxy, "target_proxy")
     }
@@ -21,13 +23,14 @@ final class PBXTargetDependencySpec: XCTestCase {
     }
 
     func test_equals_shouldReturnTheRightValue() {
-        let one = PBXTargetDependency(target: "target", targetProxy: "target_proxy")
-        let another = PBXTargetDependency(target: "target", targetProxy: "target_proxy")
+        let one = PBXTargetDependency(name: "name", target: "target", targetProxy: "target_proxy")
+        let another = PBXTargetDependency(name: "name", target: "target", targetProxy: "target_proxy")
         XCTAssertEqual(one, another)
     }
 
     private func testDictionary() -> [String: Any] {
         return [
+            "name": "name",
             "target": "target",
             "targetProxy": "targetProxy",
             "reference": "reference"


### PR DESCRIPTION
### Short description 📝
Add properties `PBXTarget` and friends to support additional optional properties in the Xcode project file and eliminate some diff noise as well.

### Solution 📦
Add a `productInstallPath` to `PBXNativeTarget` and a `name` property to `PBXTargetDependency`, which was discovered while analyzing the 218 in our code base. Fix diff noise when writing `PBXAggregateTarget`.

### Implementation 👩‍💻👨‍💻
- [x] Verify Xcode omits the `buildRules` for `PBXAggregateTarget` even if the user adds a custom rule

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/241)
<!-- Reviewable:end -->
