### PR TITLE
Emit More Comments in Xcode Project Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `PBXNativeTarget.productInstallPath`, `PBXTargetDependency.name` https://github.com/xcodeswift/xcproj/pull/241 by @briantkelley
+- `PBXContainerItem` super class of `PBXBuildPhase` and `PBXTarget` https://github.com/xcodeswift/xcproj/pull/243 by @briantkelley
 
 ### Changed
 - Support for `XCConfig` project-relative includes https://github.com/xcodeswift/xcproj/pull/238 by @briantkelley
@@ -14,6 +15,7 @@
 - `PBXAggregateTarget` does not write `buildRules` https://github.com/xcodeswift/xcproj/pull/241 by @briantkelley
 - Writes showEnvVarsInLog only when false https://github.com/xcodeswift/xcproj/pull/240 by @briantkelley
 - Writes `PBXProject.projectReferences` to the plist https://github.com/xcodeswift/xcproj/pull/242 by @briantkelley
+- Comment generation for `PBXProject`, `PBXTarget`, and `PBXVariantGroup` https://github.com/xcodeswift/xcproj/pull/243 by @briantkelley
 
 ## 4.1.0
 

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -41,7 +41,9 @@
 		BF_197339107955 /* CommentedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_540968018524 /* CommentedString.swift */; };
 		BF_199932632107 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_718456312730 /* XCWorkspaceDataFileRef.swift */; };
 		BF_200793912846 /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_345385210871 /* PBXLegacyTarget.swift */; };
+		BF_203164426079 /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_160410851218 /* PBXContainerItem.swift */; };
 		BF_207027417028 /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_441115400167 /* PBXCopyFilesBuildPhase.swift */; };
+		BF_209470488351 /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_160410851218 /* PBXContainerItem.swift */; };
 		BF_211212486188 /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_473541966361 /* PBXBuildPhase.swift */; };
 		BF_213934473857 /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_487766461346 /* BuildPhase.swift */; };
 		BF_215935130772 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_465638731034 /* PBXNativeTarget.swift */; };
@@ -95,6 +97,7 @@
 		BF_387846167886 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_646438073479 /* XCVersionGroup.swift */; };
 		BF_388442335726 /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_595642817891 /* PlistValue.swift */; };
 		BF_389184731012 /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_335866194901 /* XCWorkspaceData.swift */; };
+		BF_389386174257 /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_160410851218 /* PBXContainerItem.swift */; };
 		BF_391690042575 /* PBXGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_788872842986 /* PBXGroup.swift */; };
 		BF_392692625971 /* PBXSourceTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_796834358564 /* PBXSourceTree.swift */; };
 		BF_393711454683 /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_690330849341 /* PBXVariantGroup.swift */; };
@@ -193,6 +196,7 @@
 		BF_677935361120 /* Referenceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_636382421107 /* Referenceable.swift */; };
 		BF_678973873536 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_597764883424 /* PBXHeadersBuildPhase.swift */; };
 		BF_682057181319 /* PBXContainerItemProxy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_194697253485 /* PBXContainerItemProxy.swift */; };
+		BF_693559444770 /* PBXContainerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_160410851218 /* PBXContainerItem.swift */; };
 		BF_695268522750 /* PBXCopyFilesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_441115400167 /* PBXCopyFilesBuildPhase.swift */; };
 		BF_697699574638 /* XCWorkspaceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_335866194901 /* XCWorkspaceData.swift */; };
 		BF_698942412038 = {isa = PBXBuildFile; fileRef = FR_269634880674 /* xcproj.framework */; };
@@ -263,6 +267,7 @@
 		FR_115502168014 /* XCWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspace.swift; sourceTree = "<group>"; };
 		FR_121340420221 /* String+Extras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extras.swift"; sourceTree = "<group>"; };
 		FR_131053434429 /* PBXProject+Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXProject+Deprecations.swift"; sourceTree = "<group>"; };
+		FR_160410851218 /* PBXContainerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXContainerItem.swift; sourceTree = "<group>"; };
 		FR_169222806073 /* PBXReferenceProxy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXReferenceProxy.swift; sourceTree = "<group>"; };
 		FR_191604473041 /* PBXBuildRule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXBuildRule.swift; sourceTree = "<group>"; };
 		FR_192331524202 /* XCBreakpointList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCBreakpointList.swift; sourceTree = "<group>"; };
@@ -426,6 +431,7 @@
 				FR_854808332905 /* PBXBuildFile.swift */,
 				FR_473541966361 /* PBXBuildPhase.swift */,
 				FR_191604473041 /* PBXBuildRule.swift */,
+				FR_160410851218 /* PBXContainerItem.swift */,
 				FR_194697253485 /* PBXContainerItemProxy.swift */,
 				FR_441115400167 /* PBXCopyFilesBuildPhase.swift */,
 				FR_869538972327 /* PBXFileElement.swift */,
@@ -626,6 +632,7 @@
 				BF_567300894440 /* PBXBuildFile.swift in Sources */,
 				BF_465991367036 /* PBXBuildPhase.swift in Sources */,
 				BF_433827842104 /* PBXBuildRule.swift in Sources */,
+				BF_389386174257 /* PBXContainerItem.swift in Sources */,
 				BF_137035089733 /* PBXContainerItemProxy.swift in Sources */,
 				BF_554010637731 /* PBXCopyFilesBuildPhase.swift in Sources */,
 				BF_842329844425 /* PBXFileElement.swift in Sources */,
@@ -692,6 +699,7 @@
 				BF_834686732390 /* PBXBuildFile.swift in Sources */,
 				BF_628033325963 /* PBXBuildPhase.swift in Sources */,
 				BF_641206902760 /* PBXBuildRule.swift in Sources */,
+				BF_209470488351 /* PBXContainerItem.swift in Sources */,
 				BF_992120767289 /* PBXContainerItemProxy.swift in Sources */,
 				BF_695268522750 /* PBXCopyFilesBuildPhase.swift in Sources */,
 				BF_223871478452 /* PBXFileElement.swift in Sources */,
@@ -758,6 +766,7 @@
 				BF_729243069547 /* PBXBuildFile.swift in Sources */,
 				BF_645839674047 /* PBXBuildPhase.swift in Sources */,
 				BF_626018937793 /* PBXBuildRule.swift in Sources */,
+				BF_203164426079 /* PBXContainerItem.swift in Sources */,
 				BF_682057181319 /* PBXContainerItemProxy.swift in Sources */,
 				BF_207027417028 /* PBXCopyFilesBuildPhase.swift in Sources */,
 				BF_277058783634 /* PBXFileElement.swift in Sources */,
@@ -824,6 +833,7 @@
 				BF_222223406697 /* PBXBuildFile.swift in Sources */,
 				BF_211212486188 /* PBXBuildPhase.swift in Sources */,
 				BF_787529811209 /* PBXBuildRule.swift in Sources */,
+				BF_693559444770 /* PBXContainerItem.swift in Sources */,
 				BF_668674861308 /* PBXContainerItemProxy.swift in Sources */,
 				BF_556112094985 /* PBXCopyFilesBuildPhase.swift in Sources */,
 				BF_793424925406 /* PBXFileElement.swift in Sources */,

--- a/Sources/xcproj/PBXBuildPhase.swift
+++ b/Sources/xcproj/PBXBuildPhase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// An absctract class for all the build phase objects
-public class PBXBuildPhase: PBXObject {
+public class PBXBuildPhase: PBXContainerItem {
     
     /// Default build action mask.
     public static let defaultBuildActionMask: UInt = 2147483647
@@ -55,8 +55,8 @@ public class PBXBuildPhase: PBXObject {
             lhs.runOnlyForDeploymentPostprocessing == rhs.runOnlyForDeploymentPostprocessing
     }
 
-    func plistValues(proj: PBXProj, reference: String) -> [CommentedString: PlistValue] {
-        var dictionary: [CommentedString: PlistValue] = [:]
+    override func plistValues(proj: PBXProj, reference: String) -> [CommentedString: PlistValue] {
+        var dictionary = super.plistValues(proj: proj, reference: reference)
         dictionary["buildActionMask"] = .string(CommentedString("\(buildActionMask)"))
         dictionary["files"] = .array(files.map { fileReference in
             let name = proj.objects.fileName(buildFileReference: fileReference)

--- a/Sources/xcproj/PBXContainerItem.swift
+++ b/Sources/xcproj/PBXContainerItem.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Class representing an element that may contain other elements.
+public class PBXContainerItem: PBXObject {
+
+    /// User comments for the object.
+    var comments: String?
+
+    // MARK: - Init
+
+    init(comments: String? = nil) {
+        self.comments = comments
+        super.init()
+    }
+
+    // MARK: - Decodable
+
+    fileprivate enum CodingKeys: String, CodingKey {
+        case comments
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.comments = try container.decodeIfPresent(.comments)
+        try super.init(from: decoder)
+    }
+
+    public override func isEqual(to object: PBXObject) -> Bool {
+        guard super.isEqual(to: object),
+            let rhs = object as? PBXContainerItem else {
+                return false
+        }
+        let lhs = self
+        return lhs.comments == rhs.comments
+    }
+
+    func plistValues(proj: PBXProj, reference: String) -> [CommentedString: PlistValue] {
+        var dictionary = [CommentedString: PlistValue]()
+        if let comments = comments {
+            dictionary["comments"] = .string(CommentedString(comments))
+        }
+        return dictionary
+    }
+
+}

--- a/Sources/xcproj/PBXProject.swift
+++ b/Sources/xcproj/PBXProject.swift
@@ -185,10 +185,12 @@ extension PBXProject: PlistSerializable {
             dictionary["knownRegions"] = PlistValue.array(knownRegions
             .map {.string(CommentedString("\($0)")) })
         }
-        
-        dictionary["mainGroup"] = .string(CommentedString(mainGroup))
+
+        let mainGroupObject = proj.objects.groups[mainGroup]
+        dictionary["mainGroup"] = .string(CommentedString(mainGroup, comment: mainGroupObject?.name ?? mainGroupObject?.path))
         if let productRefGroup = productRefGroup {
-            let productRefGroupComment = proj.objects.groups[productRefGroup]?.name
+            let productRefGroupObject = proj.objects.groups[productRefGroup]
+            let productRefGroupComment = productRefGroupObject?.name ?? productRefGroupObject?.path
             dictionary["productRefGroup"] = .string(CommentedString(productRefGroup,
                                                                     comment: productRefGroupComment))
         }

--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -102,7 +102,7 @@ public class PBXTarget: PBXContainerItem {
 
         // Xcode doesn't write PBXAggregateTarget buildRules or empty PBXLegacyTarget buildRules
         if !(self is PBXAggregateTarget), !(self is PBXLegacyTarget) || !buildRules.isEmpty {
-            dictionary["buildRules"] = .array(buildRules.map {.string(CommentedString($0))})
+            dictionary["buildRules"] = .array(buildRules.map {.string(CommentedString($0, comment: PBXBuildRule.isa))})
         }
         
         dictionary["dependencies"] = .array(dependencies.map {.string(CommentedString($0, comment: PBXTargetDependency.isa))})

--- a/Sources/xcproj/PBXTarget.swift
+++ b/Sources/xcproj/PBXTarget.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element is an abstract parent for specialized targets.
-public class PBXTarget: PBXObject {
+public class PBXTarget: PBXContainerItem {
 
     /// Target build configuration list.
     public var buildConfigurationList: String?
@@ -88,7 +88,7 @@ public class PBXTarget: PBXObject {
     }
 
     func plistValues(proj: PBXProj, isa: String, reference: String) -> (key: CommentedString, value: PlistValue) {
-        var dictionary: [CommentedString: PlistValue] = [:]
+        var dictionary = super.plistValues(proj: proj, reference: reference)
         dictionary["isa"] = .string(CommentedString(isa))
         let buildConfigurationListComment = "Build configuration list for \(isa) \"\(name)\""
         if let buildConfigurationList = buildConfigurationList {

--- a/Sources/xcproj/PBXVariantGroup.swift
+++ b/Sources/xcproj/PBXVariantGroup.swift
@@ -58,8 +58,7 @@ final public class PBXVariantGroup: PBXFileElement {
         dictionary["isa"] = .string(CommentedString(PBXVariantGroup.isa))
         dictionary["children"] = .array(children
             .map({PlistValue.string(CommentedString($0, comment: proj.objects.fileName(fileReference: $0)))}))
-        return (key: CommentedString(reference,
-                                                 comment: name),
+        return (key: CommentedString(reference, comment: name ?? path),
                 value: .dictionary(dictionary))
     }
 }


### PR DESCRIPTION
### Short description 📝
Update xcproj to support the `comment` property and to fix diff noise when creating plist entires for `PBXVariantGroup`, `PBXProject`, and `PBXTarget`.

### Solution 📦
Add support for the `comment` property via a new `PBXContainerItem` class, which follows Xcode's design based on a Google class-dump header search. Update comment generation `PBXVariantGroup`, `PBXProject`, and `PBXTarget` to eliminate diff noise found when writing the 218 with xcproj.

### Implementation 👩‍💻👨‍💻
- [x] Add `PBXContainerItem` to support the `comment` property, matching the behavior from a class-dump search, and make it the super class of `PBXBuildPhase` and `PBXTarget`.
- [x] When creating the comment fo `PBXVariantGroup`, fall back to `path` if `name` is `nil`.
- [x] Similarly, when creating the comment for `PBXProject.mainGroup` and `PBXProject.productRefGroup`, fall back to `path` if `name` is `nil`.
- [x] `PBXTarget.buildRules` emits the `isa` as the comment, similar to the `dependencies` property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/243)
<!-- Reviewable:end -->
