### PR TITLE
Add Properties PBXFileElement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,15 @@
 ### Added
 - `PBXNativeTarget.productInstallPath`, `PBXTargetDependency.name` https://github.com/xcodeswift/xcproj/pull/241 by @briantkelley
 - `PBXContainerItem` super class of `PBXBuildPhase` and `PBXTarget` https://github.com/xcodeswift/xcproj/pull/243 by @briantkelley
+- `PBXFileElement.wrapsLines`property https://github.com/xcodeswift/xcproj/pull/244 by @briantkelley
+- `PBXFileReference` `languageSpecificationIdentifier` and `plistStructureDefinitionIdentifier` properties https://github.com/xcodeswift/xcproj/pull/244 by @briantkelley
 
 ### Changed
 - Support for `XCConfig` project-relative includes https://github.com/xcodeswift/xcproj/pull/238 by @briantkelley
 - Migrated `PBXProject.projectRoot` to `PBXProject.projectRoots` https://github.com/xcodeswift/xcproj/pull/242 by @briantkelley
+- Moved `PBXFileElement.includeInIndex` and `PBXGroup`'s `usesTabs`, `indentWidth`, and `tabWidth` properties to `PBXFileElement` https://github.com/xcodeswift/xcproj/pull/244 by @briantkelley
+- `PBXContainerItem` super class of `PBXFileElement` https://github.com/xcodeswift/xcproj/pull/244 by @briantkelley
+- `PBXVariantGroup` and `XCVersionGroup` now inherit from `PBXGroup` https://github.com/xcodeswift/xcproj/pull/244 by @briantkelley
 
 ### Fixed
 - `PBXObject.isEqual(to:)` overrides correctly call super https://github.com/xcodeswift/xcproj/pull/239 by @briantkelley

--- a/Carthage.xcodeproj/project.pbxproj
+++ b/Carthage.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		BF_100849539797 /* PBXFileReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_753508207372 /* PBXFileReference.swift */; };
 		BF_101548842057 /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_345385210871 /* PBXLegacyTarget.swift */; };
+		BF_103972784826 /* PBXVariantGroup+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_264082505622 /* PBXVariantGroup+Deprecations.swift */; };
 		BF_107218696993 /* BuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_487766461346 /* BuildPhase.swift */; };
 		BF_116125884111 /* PBXProjObjects+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_880710663053 /* PBXProjObjects+Helpers.swift */; };
 		BF_118670594622 /* XCSharedData.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_486803725803 /* XCSharedData.swift */; };
@@ -92,6 +93,7 @@
 		BF_363708474724 /* XCWorkspaceDataFileRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_718456312730 /* XCWorkspaceDataFileRef.swift */; };
 		BF_367792059165 /* PBXProject+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_131053434429 /* PBXProject+Deprecations.swift */; };
 		BF_368295940121 /* PBXHeadersBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_597764883424 /* PBXHeadersBuildPhase.swift */; };
+		BF_368638839913 /* PBXVariantGroup+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_264082505622 /* PBXVariantGroup+Deprecations.swift */; };
 		BF_370086358951 /* Referenceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_636382421107 /* Referenceable.swift */; };
 		BF_372483883769 /* PBXProj+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_852367716413 /* PBXProj+Helpers.swift */; };
 		BF_387846167886 /* XCVersionGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_646438073479 /* XCVersionGroup.swift */; };
@@ -123,6 +125,7 @@
 		BF_452980074675 /* PBXObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_757027346462 /* PBXObject.swift */; };
 		BF_455098138370 /* XCScheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_233593682006 /* XCScheme.swift */; };
 		BF_461567992807 /* PBXVariantGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_690330849341 /* PBXVariantGroup.swift */; };
+		BF_462613734296 /* PBXVariantGroup+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_264082505622 /* PBXVariantGroup+Deprecations.swift */; };
 		BF_465991367036 /* PBXBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_473541966361 /* PBXBuildPhase.swift */; };
 		BF_466129653283 /* PBXNativeTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_465638731034 /* PBXNativeTarget.swift */; };
 		BF_467107176803 = {isa = PBXBuildFile; fileRef = FR_416349087825 /* xcproj.framework */; };
@@ -144,6 +147,7 @@
 		BF_496503727859 /* PlistValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_595642817891 /* PlistValue.swift */; };
 		BF_497250532679 /* XCWorkspaceDataElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_452125827828 /* XCWorkspaceDataElement.swift */; };
 		BF_506747336569 /* XcodeProj.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_852424823857 /* XcodeProj.swift */; };
+		BF_514094334166 /* PBXVariantGroup+Deprecations.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_264082505622 /* PBXVariantGroup+Deprecations.swift */; };
 		BF_514469998107 /* PBXSourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_591573173582 /* PBXSourcesBuildPhase.swift */; };
 		BF_515258794140 /* PBXResourcesBuildPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_569579805119 /* PBXResourcesBuildPhase.swift */; };
 		BF_525420467422 /* PBXLegacyTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_345385210871 /* PBXLegacyTarget.swift */; };
@@ -277,6 +281,7 @@
 		FR_233593682006 /* XCScheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCScheme.swift; sourceTree = "<group>"; };
 		FR_236533062777 /* PBXProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXProductType.swift; sourceTree = "<group>"; };
 		FR_240508634712 /* PathKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = PathKit.framework; sourceTree = "<group>"; };
+		FR_264082505622 /* PBXVariantGroup+Deprecations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PBXVariantGroup+Deprecations.swift"; sourceTree = "<group>"; };
 		FR_269634880674 /* xcproj.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = xcproj.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_335866194901 /* XCWorkspaceData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCWorkspaceData.swift; sourceTree = "<group>"; };
 		FR_345385210871 /* PBXLegacyTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PBXLegacyTarget.swift; sourceTree = "<group>"; };
@@ -458,6 +463,7 @@
 				FR_591573173582 /* PBXSourcesBuildPhase.swift */,
 				FR_444580546237 /* PBXTarget.swift */,
 				FR_587989700167 /* PBXTargetDependency.swift */,
+				FR_264082505622 /* PBXVariantGroup+Deprecations.swift */,
 				FR_690330849341 /* PBXVariantGroup.swift */,
 				FR_595642817891 /* PlistValue.swift */,
 				FR_636382421107 /* Referenceable.swift */,
@@ -659,6 +665,7 @@
 				BF_337620897652 /* PBXSourcesBuildPhase.swift in Sources */,
 				BF_399860543920 /* PBXTarget.swift in Sources */,
 				BF_555529016894 /* PBXTargetDependency.swift in Sources */,
+				BF_368638839913 /* PBXVariantGroup+Deprecations.swift in Sources */,
 				BF_461567992807 /* PBXVariantGroup.swift in Sources */,
 				BF_796452314497 /* PlistValue.swift in Sources */,
 				BF_232314226366 /* Referenceable.swift in Sources */,
@@ -726,6 +733,7 @@
 				BF_549794542058 /* PBXSourcesBuildPhase.swift in Sources */,
 				BF_258116106712 /* PBXTarget.swift in Sources */,
 				BF_669576479010 /* PBXTargetDependency.swift in Sources */,
+				BF_103972784826 /* PBXVariantGroup+Deprecations.swift in Sources */,
 				BF_393711454683 /* PBXVariantGroup.swift in Sources */,
 				BF_496503727859 /* PlistValue.swift in Sources */,
 				BF_437045913759 /* Referenceable.swift in Sources */,
@@ -793,6 +801,7 @@
 				BF_799350912634 /* PBXSourcesBuildPhase.swift in Sources */,
 				BF_840440649933 /* PBXTarget.swift in Sources */,
 				BF_135621213980 /* PBXTargetDependency.swift in Sources */,
+				BF_462613734296 /* PBXVariantGroup+Deprecations.swift in Sources */,
 				BF_223588338891 /* PBXVariantGroup.swift in Sources */,
 				BF_388442335726 /* PlistValue.swift in Sources */,
 				BF_370086358951 /* Referenceable.swift in Sources */,
@@ -860,6 +869,7 @@
 				BF_514469998107 /* PBXSourcesBuildPhase.swift in Sources */,
 				BF_553331683590 /* PBXTarget.swift in Sources */,
 				BF_183165796490 /* PBXTargetDependency.swift in Sources */,
+				BF_514094334166 /* PBXVariantGroup+Deprecations.swift in Sources */,
 				BF_127958136818 /* PBXVariantGroup.swift in Sources */,
 				BF_868835969906 /* PlistValue.swift in Sources */,
 				BF_677935361120 /* Referenceable.swift in Sources */,

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -23,6 +23,9 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     /// Element indent width.
     public var indentWidth: UInt?
 
+    /// Element tab width.
+    public var tabWidth: UInt?
+
     /// Element wraps lines.
     public var wrapsLines: Bool?
 
@@ -36,6 +39,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     ///   - includeInIndex: should the IDE index the object?
     ///   - usesTabs: object uses tabs.
     ///   - indentWidth: the number of positions to indent blocks of code
+    ///   - tabWidth: the visual width of tab characters
     ///   - wrapsLines: should the IDE wrap lines when editing the object?
     public init(sourceTree: PBXSourceTree? = nil,
                 path: String? = nil,
@@ -43,6 +47,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
                 includeInIndex: Bool? = nil,
                 usesTabs: Bool? = nil,
                 indentWidth: UInt? = nil,
+                tabWidth: UInt? = nil,
                 wrapsLines: Bool? = nil) {
         self.sourceTree = sourceTree
         self.path = path
@@ -50,6 +55,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         self.includeInIndex = includeInIndex
         self.usesTabs = usesTabs
         self.indentWidth = indentWidth
+        self.tabWidth = tabWidth
         self.wrapsLines = wrapsLines
         super.init()
     }
@@ -66,6 +72,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
             lhs.includeInIndex == rhs.includeInIndex &&
             lhs.usesTabs == rhs.usesTabs &&
             lhs.indentWidth == rhs.indentWidth &&
+            lhs.tabWidth == rhs.tabWidth &&
             lhs.wrapsLines == rhs.wrapsLines
     }
     
@@ -78,6 +85,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         case includeInIndex
         case usesTabs
         case indentWidth
+        case tabWidth
         case wrapsLines
     }
     
@@ -89,6 +97,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         self.includeInIndex = try container.decodeIntBoolIfPresent(.includeInIndex)
         self.usesTabs = try container.decodeIntBoolIfPresent(.usesTabs)
         self.indentWidth = try container.decodeIntIfPresent(.indentWidth)
+        self.tabWidth = try container.decodeIntIfPresent(.tabWidth)
         self.wrapsLines = try container.decodeIntBoolIfPresent(.wrapsLines)
         try super.init(from: decoder)
     }
@@ -118,6 +127,9 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         }
         if let indentWidth = indentWidth {
             dictionary["indentWidth"] = .string(CommentedString("\(indentWidth)"))
+        }
+        if let tabWidth = tabWidth {
+            dictionary["tabWidth"] = .string(CommentedString("\(tabWidth)"))
         }
         if let wrapsLines = wrapsLines {
             dictionary["wrapsLines"] = .string(CommentedString("\(wrapsLines.int)"))

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -13,7 +13,10 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     
     /// Element name.
     public var name: String?
-    
+
+    /// Element wraps lines.
+    public var wrapsLines: Bool?
+
     // MARK: - Init
     
     /// Initializes the file element with its properties.
@@ -21,12 +24,15 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     /// - Parameters:
     ///   - sourceTree: file source tree.
     ///   - name: file name.
+    ///   - wrapsLines: should the IDE wrap lines when editing the object?
     public init(sourceTree: PBXSourceTree? = nil,
                 path: String? = nil,
-                name: String? = nil) {
+                name: String? = nil,
+                wrapsLines: Bool? = nil) {
         self.sourceTree = sourceTree
         self.path = path
         self.name = name
+        self.wrapsLines = wrapsLines
         super.init()
     }
     
@@ -38,7 +44,8 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         let lhs = self
         return lhs.sourceTree == rhs.sourceTree &&
             lhs.path == rhs.path &&
-            lhs.name == rhs.name
+            lhs.name == rhs.name &&
+            lhs.wrapsLines == rhs.wrapsLines
     }
     
     // MARK: - Decodable
@@ -47,6 +54,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         case sourceTree
         case name
         case path
+        case wrapsLines
     }
     
     public required init(from decoder: Decoder) throws {
@@ -54,6 +62,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         self.sourceTree = try container.decodeIfPresent(String.self, forKey: .sourceTree).map { PBXSourceTree(value: $0) }
         self.name = try container.decodeIfPresent(.name)
         self.path = try container.decodeIfPresent(.path)
+        self.wrapsLines = try container.decodeIntBoolIfPresent(.wrapsLines)
         try super.init(from: decoder)
     }
     
@@ -72,6 +81,9 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         }
         if let sourceTree = sourceTree {
             dictionary["sourceTree"] = sourceTree.plist()
+        }
+        if let wrapsLines = wrapsLines {
+            dictionary["wrapsLines"] = .string(CommentedString("\(wrapsLines.int)"))
         }
         return (key: CommentedString(reference,
                                      comment: self.name),

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This element is an abstract parent for file and group elements.
-public class PBXFileElement: PBXObject, PlistSerializable {
+public class PBXFileElement: PBXContainerItem, PlistSerializable {
     
     // MARK: - Attributes
 

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -17,6 +17,9 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     /// Element include in index.
     public var includeInIndex: Bool?
 
+    /// Element uses tabs.
+    public var usesTabs: Bool?
+
     /// Element wraps lines.
     public var wrapsLines: Bool?
 
@@ -28,16 +31,19 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     ///   - sourceTree: file source tree.
     ///   - name: file name.
     ///   - includeInIndex: should the IDE index the object?
+    ///   - usesTabs: object uses tabs.
     ///   - wrapsLines: should the IDE wrap lines when editing the object?
     public init(sourceTree: PBXSourceTree? = nil,
                 path: String? = nil,
                 name: String? = nil,
                 includeInIndex: Bool? = nil,
+                usesTabs: Bool? = nil,
                 wrapsLines: Bool? = nil) {
         self.sourceTree = sourceTree
         self.path = path
         self.name = name
         self.includeInIndex = includeInIndex
+        self.usesTabs = usesTabs
         self.wrapsLines = wrapsLines
         super.init()
     }
@@ -52,6 +58,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
             lhs.path == rhs.path &&
             lhs.name == rhs.name &&
             lhs.includeInIndex == rhs.includeInIndex &&
+            lhs.usesTabs == rhs.usesTabs &&
             lhs.wrapsLines == rhs.wrapsLines
     }
     
@@ -62,6 +69,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         case name
         case path
         case includeInIndex
+        case usesTabs
         case wrapsLines
     }
     
@@ -71,6 +79,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         self.name = try container.decodeIfPresent(.name)
         self.path = try container.decodeIfPresent(.path)
         self.includeInIndex = try container.decodeIntBoolIfPresent(.includeInIndex)
+        self.usesTabs = try container.decodeIntBoolIfPresent(.usesTabs)
         self.wrapsLines = try container.decodeIntBoolIfPresent(.wrapsLines)
         try super.init(from: decoder)
     }
@@ -93,6 +102,9 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         }
         if let includeInIndex = includeInIndex {
             dictionary["includeInIndex"] = .string(CommentedString("\(includeInIndex.int)"))
+        }
+        if let usesTabs = usesTabs {
+            dictionary["usesTabs"] = .string(CommentedString("\(usesTabs.int)"))
         }
         if let wrapsLines = wrapsLines {
             dictionary["wrapsLines"] = .string(CommentedString("\(wrapsLines.int)"))

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -35,7 +35,8 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     ///
     /// - Parameters:
     ///   - sourceTree: file source tree.
-    ///   - name: file name.
+    ///   - path: object relative path from `sourceTree`, if different than `name`.
+    ///   - name: object name.
     ///   - includeInIndex: should the IDE index the object?
     ///   - usesTabs: object uses tabs.
     ///   - indentWidth: the number of positions to indent blocks of code

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -14,6 +14,9 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     /// Element name.
     public var name: String?
 
+    /// Element include in index.
+    public var includeInIndex: Bool?
+
     /// Element wraps lines.
     public var wrapsLines: Bool?
 
@@ -24,14 +27,17 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     /// - Parameters:
     ///   - sourceTree: file source tree.
     ///   - name: file name.
+    ///   - includeInIndex: should the IDE index the object?
     ///   - wrapsLines: should the IDE wrap lines when editing the object?
     public init(sourceTree: PBXSourceTree? = nil,
                 path: String? = nil,
                 name: String? = nil,
+                includeInIndex: Bool? = nil,
                 wrapsLines: Bool? = nil) {
         self.sourceTree = sourceTree
         self.path = path
         self.name = name
+        self.includeInIndex = includeInIndex
         self.wrapsLines = wrapsLines
         super.init()
     }
@@ -45,6 +51,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         return lhs.sourceTree == rhs.sourceTree &&
             lhs.path == rhs.path &&
             lhs.name == rhs.name &&
+            lhs.includeInIndex == rhs.includeInIndex &&
             lhs.wrapsLines == rhs.wrapsLines
     }
     
@@ -54,6 +61,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         case sourceTree
         case name
         case path
+        case includeInIndex
         case wrapsLines
     }
     
@@ -62,6 +70,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         self.sourceTree = try container.decodeIfPresent(String.self, forKey: .sourceTree).map { PBXSourceTree(value: $0) }
         self.name = try container.decodeIfPresent(.name)
         self.path = try container.decodeIfPresent(.path)
+        self.includeInIndex = try container.decodeIntBoolIfPresent(.includeInIndex)
         self.wrapsLines = try container.decodeIntBoolIfPresent(.wrapsLines)
         try super.init(from: decoder)
     }
@@ -81,6 +90,9 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         }
         if let sourceTree = sourceTree {
             dictionary["sourceTree"] = sourceTree.plist()
+        }
+        if let includeInIndex = includeInIndex {
+            dictionary["includeInIndex"] = .string(CommentedString("\(includeInIndex.int)"))
         }
         if let wrapsLines = wrapsLines {
             dictionary["wrapsLines"] = .string(CommentedString("\(wrapsLines.int)"))

--- a/Sources/xcproj/PBXFileElement.swift
+++ b/Sources/xcproj/PBXFileElement.swift
@@ -20,6 +20,9 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     /// Element uses tabs.
     public var usesTabs: Bool?
 
+    /// Element indent width.
+    public var indentWidth: UInt?
+
     /// Element wraps lines.
     public var wrapsLines: Bool?
 
@@ -32,18 +35,21 @@ public class PBXFileElement: PBXObject, PlistSerializable {
     ///   - name: file name.
     ///   - includeInIndex: should the IDE index the object?
     ///   - usesTabs: object uses tabs.
+    ///   - indentWidth: the number of positions to indent blocks of code
     ///   - wrapsLines: should the IDE wrap lines when editing the object?
     public init(sourceTree: PBXSourceTree? = nil,
                 path: String? = nil,
                 name: String? = nil,
                 includeInIndex: Bool? = nil,
                 usesTabs: Bool? = nil,
+                indentWidth: UInt? = nil,
                 wrapsLines: Bool? = nil) {
         self.sourceTree = sourceTree
         self.path = path
         self.name = name
         self.includeInIndex = includeInIndex
         self.usesTabs = usesTabs
+        self.indentWidth = indentWidth
         self.wrapsLines = wrapsLines
         super.init()
     }
@@ -59,6 +65,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
             lhs.name == rhs.name &&
             lhs.includeInIndex == rhs.includeInIndex &&
             lhs.usesTabs == rhs.usesTabs &&
+            lhs.indentWidth == rhs.indentWidth &&
             lhs.wrapsLines == rhs.wrapsLines
     }
     
@@ -70,6 +77,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         case path
         case includeInIndex
         case usesTabs
+        case indentWidth
         case wrapsLines
     }
     
@@ -80,6 +88,7 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         self.path = try container.decodeIfPresent(.path)
         self.includeInIndex = try container.decodeIntBoolIfPresent(.includeInIndex)
         self.usesTabs = try container.decodeIntBoolIfPresent(.usesTabs)
+        self.indentWidth = try container.decodeIntIfPresent(.indentWidth)
         self.wrapsLines = try container.decodeIntBoolIfPresent(.wrapsLines)
         try super.init(from: decoder)
     }
@@ -100,11 +109,15 @@ public class PBXFileElement: PBXObject, PlistSerializable {
         if let sourceTree = sourceTree {
             dictionary["sourceTree"] = sourceTree.plist()
         }
+
         if let includeInIndex = includeInIndex {
             dictionary["includeInIndex"] = .string(CommentedString("\(includeInIndex.int)"))
         }
         if let usesTabs = usesTabs {
             dictionary["usesTabs"] = .string(CommentedString("\(usesTabs.int)"))
+        }
+        if let indentWidth = indentWidth {
+            dictionary["indentWidth"] = .string(CommentedString("\(indentWidth)"))
         }
         if let wrapsLines = wrapsLines {
             dictionary["wrapsLines"] = .string(CommentedString("\(wrapsLines.int)"))

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -16,9 +16,6 @@ final public class PBXFileReference: PBXFileElement {
     /// Element last known file type.
     public var lastKnownFileType: String?
     
-    /// Element include in index.
-    public var includeInIndex: Bool?
-    
     /// Element uses tabs.
     public var usesTabs: Bool?
     
@@ -30,6 +27,7 @@ final public class PBXFileReference: PBXFileElement {
     
     // MARK: - Init
     
+    ///   - includeInIndex: should the IDE index the file?
     ///   - wrapsLines: should the IDE wrap lines when editing the file?
     public init(sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
@@ -45,11 +43,10 @@ final public class PBXFileReference: PBXFileElement {
         self.fileEncoding = fileEncoding
         self.explicitFileType = explicitFileType
         self.lastKnownFileType = lastKnownFileType
-        self.includeInIndex = includeInIndex
         self.usesTabs = usesTabs
         self.lineEnding = lineEnding
         self.xcLanguageSpecificationIdentifier = xcLanguageSpecificationIdentifier
-        super.init(sourceTree: sourceTree, path: path, name: name, wrapsLines: wrapsLines)
+        super.init(sourceTree: sourceTree, path: path, name: name, includeInIndex: includeInIndex, wrapsLines: wrapsLines)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {
@@ -64,7 +61,6 @@ final public class PBXFileReference: PBXFileElement {
             lhs.name == rhs.name &&
             lhs.path == rhs.path &&
             lhs.sourceTree == rhs.sourceTree &&
-            lhs.includeInIndex == rhs.includeInIndex &&
             lhs.usesTabs == rhs.usesTabs &&
             lhs.lineEnding == rhs.lineEnding &&
             lhs.xcLanguageSpecificationIdentifier == rhs.xcLanguageSpecificationIdentifier
@@ -76,7 +72,6 @@ final public class PBXFileReference: PBXFileElement {
         case fileEncoding
         case explicitFileType
         case lastKnownFileType
-        case includeInIndex
         case usesTabs
         case lineEnding
         case xcLanguageSpecificationIdentifier
@@ -87,7 +82,6 @@ final public class PBXFileReference: PBXFileElement {
         self.fileEncoding = try container.decodeIntIfPresent(.fileEncoding)
         self.explicitFileType = try container.decodeIfPresent(.explicitFileType)
         self.lastKnownFileType = try container.decodeIfPresent(.lastKnownFileType)
-        self.includeInIndex = try container.decodeIntBoolIfPresent(.includeInIndex)
         self.usesTabs = try container.decodeIntBoolIfPresent(.usesTabs)
         self.lineEnding = try container.decodeIntIfPresent(.lineEnding)
         self.xcLanguageSpecificationIdentifier = try container.decodeIfPresent(.xcLanguageSpecificationIdentifier)
@@ -110,9 +104,6 @@ final public class PBXFileReference: PBXFileElement {
         }
         if let explicitFileType = self.explicitFileType {
             dictionary["explicitFileType"] = .string(CommentedString(explicitFileType))
-        }
-        if let includeInIndex = includeInIndex {
-            dictionary["includeInIndex"] = .string(CommentedString("\(includeInIndex.int)"))
         }
         if let usesTabs = usesTabs {
             dictionary["usesTabs"] = .string(CommentedString("\(usesTabs.int)"))

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -66,9 +66,6 @@ final public class PBXFileReference: PBXFileElement {
         return lhs.fileEncoding == rhs.fileEncoding &&
             lhs.explicitFileType == rhs.explicitFileType &&
             lhs.lastKnownFileType == rhs.lastKnownFileType &&
-            lhs.name == rhs.name &&
-            lhs.path == rhs.path &&
-            lhs.sourceTree == rhs.sourceTree &&
             lhs.lineEnding == rhs.lineEnding &&
             lhs.xcLanguageSpecificationIdentifier == rhs.xcLanguageSpecificationIdentifier
     }

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -19,16 +19,35 @@ final public class PBXFileReference: PBXFileElement {
     /// Element line ending.
     public var lineEnding: UInt?
     
+    /// Element language specification identifier
+    public var languageSpecificationIdentifier: String?
+
     /// Element xc language specification identifier
     public var xcLanguageSpecificationIdentifier: String?
     
+    /// Element plist structure definition identifier
+    public var plistStructureDefinitionIdentifier: String?
+
     // MARK: - Init
     
+    /// Initializes the file reference with its properties.
+    ///
+    /// - Parameters:
+    ///   - sourceTree: file source tree.
+    ///   - name: file name.
+    ///   - fileEncoding: text encoding of file content.
+    ///   - explicitFileType: user-specified file type.
+    ///   - lastKnownFileType: derived file type.
+    ///   - path: file relative path from `sourceTree`, if different than `name`.
     ///   - includeInIndex: should the IDE index the file?
     ///   - wrapsLines: should the IDE wrap lines when editing the file?
     ///   - usesTabs: file uses tabs.
     ///   - indentWidth: the number of positions to indent blocks of code
     ///   - tabWidth: the visual width of tab characters
+    ///   - lineEnding: the line ending type for the file.
+    ///   - languageSpecificationIdentifier: legacy programming language identifier.
+    ///   - xcLanguageSpecificationIdentifier: the programming language identifier.
+    ///   - plistStructureDefinitionIdentifier: the plist organizational family identifier.
     public init(sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
                 fileEncoding: UInt? = nil,
@@ -41,12 +60,16 @@ final public class PBXFileReference: PBXFileElement {
                 indentWidth: UInt? = nil,
                 tabWidth: UInt? = nil,
                 lineEnding: UInt? = nil,
-                xcLanguageSpecificationIdentifier: String? = nil) {
+                languageSpecificationIdentifier: String? = nil,
+                xcLanguageSpecificationIdentifier: String? = nil,
+                plistStructureDefinitionIdentifier: String? = nil) {
         self.fileEncoding = fileEncoding
         self.explicitFileType = explicitFileType
         self.lastKnownFileType = lastKnownFileType
         self.lineEnding = lineEnding
+        self.languageSpecificationIdentifier = languageSpecificationIdentifier
         self.xcLanguageSpecificationIdentifier = xcLanguageSpecificationIdentifier
+        self.plistStructureDefinitionIdentifier = plistStructureDefinitionIdentifier
         super.init(sourceTree: sourceTree,
                    path: path,
                    name: name,
@@ -67,7 +90,9 @@ final public class PBXFileReference: PBXFileElement {
             lhs.explicitFileType == rhs.explicitFileType &&
             lhs.lastKnownFileType == rhs.lastKnownFileType &&
             lhs.lineEnding == rhs.lineEnding &&
-            lhs.xcLanguageSpecificationIdentifier == rhs.xcLanguageSpecificationIdentifier
+            lhs.languageSpecificationIdentifier == rhs.languageSpecificationIdentifier &&
+            lhs.xcLanguageSpecificationIdentifier == rhs.xcLanguageSpecificationIdentifier &&
+            lhs.plistStructureDefinitionIdentifier == rhs.plistStructureDefinitionIdentifier
     }
     
     // MARK: - Decodable
@@ -77,7 +102,9 @@ final public class PBXFileReference: PBXFileElement {
         case explicitFileType
         case lastKnownFileType
         case lineEnding
+        case languageSpecificationIdentifier
         case xcLanguageSpecificationIdentifier
+        case plistStructureDefinitionIdentifier
     }
     
     public required init(from decoder: Decoder) throws {
@@ -86,7 +113,9 @@ final public class PBXFileReference: PBXFileElement {
         self.explicitFileType = try container.decodeIfPresent(.explicitFileType)
         self.lastKnownFileType = try container.decodeIfPresent(.lastKnownFileType)
         self.lineEnding = try container.decodeIntIfPresent(.lineEnding)
+        self.languageSpecificationIdentifier = try container.decodeIfPresent(.languageSpecificationIdentifier)
         self.xcLanguageSpecificationIdentifier = try container.decodeIfPresent(.xcLanguageSpecificationIdentifier)
+        self.plistStructureDefinitionIdentifier = try container.decodeIfPresent(.plistStructureDefinitionIdentifier)
         try super.init(from: decoder)
     }
     
@@ -110,8 +139,14 @@ final public class PBXFileReference: PBXFileElement {
         if let lineEnding = lineEnding {
             dictionary["lineEnding"] = .string(CommentedString("\(lineEnding)"))
         }
+        if let languageSpecificationIdentifier = languageSpecificationIdentifier {
+            dictionary["languageSpecificationIdentifier"] = .string(CommentedString(languageSpecificationIdentifier))
+        }
         if let xcLanguageSpecificationIdentifier = xcLanguageSpecificationIdentifier {
             dictionary["xcLanguageSpecificationIdentifier"] = .string(CommentedString(xcLanguageSpecificationIdentifier))
+        }
+        if let plistStructureDefinitionIdentifier = plistStructureDefinitionIdentifier {
+            dictionary["plistStructureDefinitionIdentifier"] = .string(CommentedString(plistStructureDefinitionIdentifier))
         }
         return (key: CommentedString(reference, comment: name ?? path),
                 value: .dictionary(dictionary))

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -30,6 +30,7 @@ final public class PBXFileReference: PBXFileElement {
     
     // MARK: - Init
     
+    ///   - wrapsLines: should the IDE wrap lines when editing the file?
     public init(sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
                 fileEncoding: UInt? = nil,
@@ -37,6 +38,7 @@ final public class PBXFileReference: PBXFileElement {
                 lastKnownFileType: String? = nil,
                 path: String? = nil,
                 includeInIndex: Bool? = nil,
+                wrapsLines: Bool? = nil,
                 usesTabs: Bool? = nil,
                 lineEnding: UInt? = nil,
                 xcLanguageSpecificationIdentifier: String? = nil) {
@@ -47,7 +49,7 @@ final public class PBXFileReference: PBXFileElement {
         self.usesTabs = usesTabs
         self.lineEnding = lineEnding
         self.xcLanguageSpecificationIdentifier = xcLanguageSpecificationIdentifier
-        super.init(sourceTree: sourceTree, path: path, name: name)
+        super.init(sourceTree: sourceTree, path: path, name: name, wrapsLines: wrapsLines)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -28,6 +28,7 @@ final public class PBXFileReference: PBXFileElement {
     ///   - wrapsLines: should the IDE wrap lines when editing the file?
     ///   - usesTabs: file uses tabs.
     ///   - indentWidth: the number of positions to indent blocks of code
+    ///   - tabWidth: the visual width of tab characters
     public init(sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
                 fileEncoding: UInt? = nil,
@@ -38,6 +39,7 @@ final public class PBXFileReference: PBXFileElement {
                 wrapsLines: Bool? = nil,
                 usesTabs: Bool? = nil,
                 indentWidth: UInt? = nil,
+                tabWidth: UInt? = nil,
                 lineEnding: UInt? = nil,
                 xcLanguageSpecificationIdentifier: String? = nil) {
         self.fileEncoding = fileEncoding
@@ -51,6 +53,7 @@ final public class PBXFileReference: PBXFileElement {
                    includeInIndex: includeInIndex,
                    usesTabs: usesTabs,
                    indentWidth: indentWidth,
+                   tabWidth: tabWidth,
                    wrapsLines: wrapsLines)
     }
 

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -27,6 +27,7 @@ final public class PBXFileReference: PBXFileElement {
     ///   - includeInIndex: should the IDE index the file?
     ///   - wrapsLines: should the IDE wrap lines when editing the file?
     ///   - usesTabs: file uses tabs.
+    ///   - indentWidth: the number of positions to indent blocks of code
     public init(sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
                 fileEncoding: UInt? = nil,
@@ -36,6 +37,7 @@ final public class PBXFileReference: PBXFileElement {
                 includeInIndex: Bool? = nil,
                 wrapsLines: Bool? = nil,
                 usesTabs: Bool? = nil,
+                indentWidth: UInt? = nil,
                 lineEnding: UInt? = nil,
                 xcLanguageSpecificationIdentifier: String? = nil) {
         self.fileEncoding = fileEncoding
@@ -43,7 +45,13 @@ final public class PBXFileReference: PBXFileElement {
         self.lastKnownFileType = lastKnownFileType
         self.lineEnding = lineEnding
         self.xcLanguageSpecificationIdentifier = xcLanguageSpecificationIdentifier
-        super.init(sourceTree: sourceTree, path: path, name: name, includeInIndex: includeInIndex, usesTabs: usesTabs, wrapsLines: wrapsLines)
+        super.init(sourceTree: sourceTree,
+                   path: path,
+                   name: name,
+                   includeInIndex: includeInIndex,
+                   usesTabs: usesTabs,
+                   indentWidth: indentWidth,
+                   wrapsLines: wrapsLines)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {

--- a/Sources/xcproj/PBXFileReference.swift
+++ b/Sources/xcproj/PBXFileReference.swift
@@ -16,9 +16,6 @@ final public class PBXFileReference: PBXFileElement {
     /// Element last known file type.
     public var lastKnownFileType: String?
     
-    /// Element uses tabs.
-    public var usesTabs: Bool?
-    
     /// Element line ending.
     public var lineEnding: UInt?
     
@@ -29,6 +26,7 @@ final public class PBXFileReference: PBXFileElement {
     
     ///   - includeInIndex: should the IDE index the file?
     ///   - wrapsLines: should the IDE wrap lines when editing the file?
+    ///   - usesTabs: file uses tabs.
     public init(sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
                 fileEncoding: UInt? = nil,
@@ -43,10 +41,9 @@ final public class PBXFileReference: PBXFileElement {
         self.fileEncoding = fileEncoding
         self.explicitFileType = explicitFileType
         self.lastKnownFileType = lastKnownFileType
-        self.usesTabs = usesTabs
         self.lineEnding = lineEnding
         self.xcLanguageSpecificationIdentifier = xcLanguageSpecificationIdentifier
-        super.init(sourceTree: sourceTree, path: path, name: name, includeInIndex: includeInIndex, wrapsLines: wrapsLines)
+        super.init(sourceTree: sourceTree, path: path, name: name, includeInIndex: includeInIndex, usesTabs: usesTabs, wrapsLines: wrapsLines)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {
@@ -61,7 +58,6 @@ final public class PBXFileReference: PBXFileElement {
             lhs.name == rhs.name &&
             lhs.path == rhs.path &&
             lhs.sourceTree == rhs.sourceTree &&
-            lhs.usesTabs == rhs.usesTabs &&
             lhs.lineEnding == rhs.lineEnding &&
             lhs.xcLanguageSpecificationIdentifier == rhs.xcLanguageSpecificationIdentifier
     }
@@ -72,7 +68,6 @@ final public class PBXFileReference: PBXFileElement {
         case fileEncoding
         case explicitFileType
         case lastKnownFileType
-        case usesTabs
         case lineEnding
         case xcLanguageSpecificationIdentifier
     }
@@ -82,7 +77,6 @@ final public class PBXFileReference: PBXFileElement {
         self.fileEncoding = try container.decodeIntIfPresent(.fileEncoding)
         self.explicitFileType = try container.decodeIfPresent(.explicitFileType)
         self.lastKnownFileType = try container.decodeIfPresent(.lastKnownFileType)
-        self.usesTabs = try container.decodeIntBoolIfPresent(.usesTabs)
         self.lineEnding = try container.decodeIntIfPresent(.lineEnding)
         self.xcLanguageSpecificationIdentifier = try container.decodeIfPresent(.xcLanguageSpecificationIdentifier)
         try super.init(from: decoder)
@@ -104,9 +98,6 @@ final public class PBXFileReference: PBXFileElement {
         }
         if let explicitFileType = self.explicitFileType {
             dictionary["explicitFileType"] = .string(CommentedString(explicitFileType))
-        }
-        if let usesTabs = usesTabs {
-            dictionary["usesTabs"] = .string(CommentedString("\(usesTabs.int)"))
         }
         if let lineEnding = lineEnding {
             dictionary["lineEnding"] = .string(CommentedString("\(lineEnding)"))

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -7,9 +7,6 @@ final public class PBXGroup: PBXFileElement {
     /// Element children.
     public var children: [String]
 
-    /// Element tab width.
-    public var tabWidth: UInt?
-
     // MARK: - Init
 
     /// Initializes the group with its attributes.
@@ -23,6 +20,7 @@ final public class PBXGroup: PBXFileElement {
     ///   - wrapsLines: should the IDE wrap lines for files in the group?
     ///   - usesTabs: group uses tabs.
     ///   - indentWidth: the number of positions to indent blocks of code
+    ///   - tabWidth: the visual width of tab characters
     public init(children: [String],
                 sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
@@ -33,13 +31,13 @@ final public class PBXGroup: PBXFileElement {
                 indentWidth: UInt? = nil,
                 tabWidth: UInt? = nil) {
         self.children = children
-        self.tabWidth = tabWidth
         super.init(sourceTree: sourceTree,
                    path: path,
                    name: name,
                    includeInIndex: includeInIndex,
                    usesTabs: usesTabs,
                    indentWidth: indentWidth,
+                   tabWidth: tabWidth,
                    wrapsLines: wrapsLines)
     }
 
@@ -52,21 +50,18 @@ final public class PBXGroup: PBXFileElement {
         return lhs.children == rhs.children &&
             lhs.name == rhs.name &&
             lhs.sourceTree == rhs.sourceTree &&
-            lhs.path == rhs.path &&
-            lhs.tabWidth == rhs.tabWidth
+            lhs.path == rhs.path
     }
     
     // MARK: - Decodable
     
     fileprivate enum CodingKeys: String, CodingKey {
         case children
-        case tabWidth
     }
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.children = (try container.decodeIfPresent(.children)) ?? []
-        self.tabWidth = try container.decodeIntIfPresent(.tabWidth)
         try super.init(from: decoder)
     }
     
@@ -79,10 +74,6 @@ final public class PBXGroup: PBXFileElement {
             let comment = proj.objects.fileName(fileReference: fileReference)
             return .string(CommentedString(fileReference, comment: comment))
         }))
-
-        if let tabWidth = tabWidth {
-            dictionary["tabWidth"] = .string(CommentedString("\(tabWidth)"))
-        }
 
         return (key: CommentedString(reference,
                                      comment: self.name ?? self.path),

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final public class PBXGroup: PBXFileElement {
+public class PBXGroup: PBXFileElement {
 
     // MARK: - Attributes
 
@@ -66,7 +66,7 @@ final public class PBXGroup: PBXFileElement {
     
     override func plistKeyAndValue(proj: PBXProj, reference: String) -> (key: CommentedString, value: PlistValue) {
         var dictionary: [CommentedString: PlistValue] = super.plistKeyAndValue(proj: proj, reference: reference).value.dictionary ?? [:]
-        dictionary["isa"] = .string(CommentedString(PBXGroup.isa))
+        dictionary["isa"] = .string(CommentedString(type(of: self).isa))
         dictionary["children"] = .array(children.map({ (fileReference) -> PlistValue in
             let comment = proj.objects.fileName(fileReference: fileReference)
             return .string(CommentedString(fileReference, comment: comment))

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -47,10 +47,7 @@ final public class PBXGroup: PBXFileElement {
                 return false
         }
         let lhs = self
-        return lhs.children == rhs.children &&
-            lhs.name == rhs.name &&
-            lhs.sourceTree == rhs.sourceTree &&
-            lhs.path == rhs.path
+        return lhs.children == rhs.children
     }
     
     // MARK: - Decodable

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -7,9 +7,6 @@ final public class PBXGroup: PBXFileElement {
     /// Element children.
     public var children: [String]
 
-    /// Element indent width.
-    public var indentWidth: UInt?
-    
     /// Element tab width.
     public var tabWidth: UInt?
 
@@ -25,6 +22,7 @@ final public class PBXGroup: PBXFileElement {
     ///   - includeInIndex: should the IDE index the files in the group?
     ///   - wrapsLines: should the IDE wrap lines for files in the group?
     ///   - usesTabs: group uses tabs.
+    ///   - indentWidth: the number of positions to indent blocks of code
     public init(children: [String],
                 sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
@@ -35,9 +33,14 @@ final public class PBXGroup: PBXFileElement {
                 indentWidth: UInt? = nil,
                 tabWidth: UInt? = nil) {
         self.children = children
-        self.indentWidth = indentWidth
         self.tabWidth = tabWidth
-        super.init(sourceTree: sourceTree, path: path, name: name, includeInIndex: includeInIndex, usesTabs: usesTabs, wrapsLines: wrapsLines)
+        super.init(sourceTree: sourceTree,
+                   path: path,
+                   name: name,
+                   includeInIndex: includeInIndex,
+                   usesTabs: usesTabs,
+                   indentWidth: indentWidth,
+                   wrapsLines: wrapsLines)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {
@@ -50,7 +53,6 @@ final public class PBXGroup: PBXFileElement {
             lhs.name == rhs.name &&
             lhs.sourceTree == rhs.sourceTree &&
             lhs.path == rhs.path &&
-            lhs.indentWidth == rhs.indentWidth &&
             lhs.tabWidth == rhs.tabWidth
     }
     
@@ -58,14 +60,12 @@ final public class PBXGroup: PBXFileElement {
     
     fileprivate enum CodingKeys: String, CodingKey {
         case children
-        case indentWidth
         case tabWidth
     }
     
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.children = (try container.decodeIfPresent(.children)) ?? []
-        self.indentWidth = try container.decodeIntIfPresent(.indentWidth)
         self.tabWidth = try container.decodeIntIfPresent(.tabWidth)
         try super.init(from: decoder)
     }
@@ -80,14 +80,10 @@ final public class PBXGroup: PBXFileElement {
             return .string(CommentedString(fileReference, comment: comment))
         }))
 
-        [("indentWidth" as CommentedString, indentWidth),
-         ("tabWidth", tabWidth)]
-            .forEach { name, valueOption in
-            if let value = valueOption {
-                dictionary[name] = .string(CommentedString("\(value)"))
-            }
+        if let tabWidth = tabWidth {
+            dictionary["tabWidth"] = .string(CommentedString("\(tabWidth)"))
         }
-        
+
         return (key: CommentedString(reference,
                                      comment: self.name ?? self.path),
                 value: .dictionary(dictionary))

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -25,11 +25,13 @@ final public class PBXGroup: PBXFileElement {
     ///   - sourceTree: group source tree.
     ///   - name: group name.
     ///   - path: group path.
+    ///   - wrapsLines: should the IDE wrap lines for files in the group?
     ///   - usesTabs: group uses tabs.
     public init(children: [String],
                 sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
                 path: String? = nil,
+                wrapsLines: Bool? = nil,
                 usesTabs: Bool? = nil,
                 indentWidth: UInt? = nil,
                 tabWidth: UInt? = nil) {
@@ -37,7 +39,7 @@ final public class PBXGroup: PBXFileElement {
         self.usesTabs = usesTabs
         self.indentWidth = indentWidth
         self.tabWidth = tabWidth
-        super.init(sourceTree: sourceTree, path: path, name: name)
+        super.init(sourceTree: sourceTree, path: path, name: name, wrapsLines: wrapsLines)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -7,9 +7,6 @@ final public class PBXGroup: PBXFileElement {
     /// Element children.
     public var children: [String]
 
-    /// Element uses tabs.
-    public var usesTabs: Bool?
-    
     /// Element indent width.
     public var indentWidth: UInt?
     
@@ -38,10 +35,9 @@ final public class PBXGroup: PBXFileElement {
                 indentWidth: UInt? = nil,
                 tabWidth: UInt? = nil) {
         self.children = children
-        self.usesTabs = usesTabs
         self.indentWidth = indentWidth
         self.tabWidth = tabWidth
-        super.init(sourceTree: sourceTree, path: path, name: name, includeInIndex: includeInIndex, wrapsLines: wrapsLines)
+        super.init(sourceTree: sourceTree, path: path, name: name, includeInIndex: includeInIndex, usesTabs: usesTabs, wrapsLines: wrapsLines)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {
@@ -54,7 +50,6 @@ final public class PBXGroup: PBXFileElement {
             lhs.name == rhs.name &&
             lhs.sourceTree == rhs.sourceTree &&
             lhs.path == rhs.path &&
-            lhs.usesTabs == rhs.usesTabs &&
             lhs.indentWidth == rhs.indentWidth &&
             lhs.tabWidth == rhs.tabWidth
     }
@@ -63,7 +58,6 @@ final public class PBXGroup: PBXFileElement {
     
     fileprivate enum CodingKeys: String, CodingKey {
         case children
-        case usesTabs
         case indentWidth
         case tabWidth
     }
@@ -71,7 +65,6 @@ final public class PBXGroup: PBXFileElement {
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.children = (try container.decodeIfPresent(.children)) ?? []
-        self.usesTabs = try container.decodeIntBoolIfPresent(.usesTabs)
         self.indentWidth = try container.decodeIntIfPresent(.indentWidth)
         self.tabWidth = try container.decodeIntIfPresent(.tabWidth)
         try super.init(from: decoder)
@@ -86,9 +79,6 @@ final public class PBXGroup: PBXFileElement {
             let comment = proj.objects.fileName(fileReference: fileReference)
             return .string(CommentedString(fileReference, comment: comment))
         }))
-        if let usesTabs = usesTabs {
-            dictionary["usesTabs"] = .string(CommentedString("\(usesTabs.int)"))
-        }
 
         [("indentWidth" as CommentedString, indentWidth),
          ("tabWidth", tabWidth)]

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -15,7 +15,7 @@ final public class PBXGroup: PBXFileElement {
     ///   - children: group children.
     ///   - sourceTree: group source tree.
     ///   - name: group name.
-    ///   - path: group path.
+    ///   - path: group relative path from `sourceTree`, if different than `name`.
     ///   - includeInIndex: should the IDE index the files in the group?
     ///   - wrapsLines: should the IDE wrap lines for files in the group?
     ///   - usesTabs: group uses tabs.

--- a/Sources/xcproj/PBXGroup.swift
+++ b/Sources/xcproj/PBXGroup.swift
@@ -25,12 +25,14 @@ final public class PBXGroup: PBXFileElement {
     ///   - sourceTree: group source tree.
     ///   - name: group name.
     ///   - path: group path.
+    ///   - includeInIndex: should the IDE index the files in the group?
     ///   - wrapsLines: should the IDE wrap lines for files in the group?
     ///   - usesTabs: group uses tabs.
     public init(children: [String],
                 sourceTree: PBXSourceTree? = nil,
                 name: String? = nil,
                 path: String? = nil,
+                includeInIndex: Bool? = nil,
                 wrapsLines: Bool? = nil,
                 usesTabs: Bool? = nil,
                 indentWidth: UInt? = nil,
@@ -39,7 +41,7 @@ final public class PBXGroup: PBXFileElement {
         self.usesTabs = usesTabs
         self.indentWidth = indentWidth
         self.tabWidth = tabWidth
-        super.init(sourceTree: sourceTree, path: path, name: name, wrapsLines: wrapsLines)
+        super.init(sourceTree: sourceTree, path: path, name: name, includeInIndex: includeInIndex, wrapsLines: wrapsLines)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -87,8 +87,9 @@ final public class PBXProj: Decodable {
         ///   - reference: object reference.
         public func addObject(_ object: PBXObject, reference: String) {
             switch object {
-            // subclass of PBXGroup; must be tested before PBXGroup
+            // subclasses of PBXGroup; must be tested before PBXGroup
             case let object as PBXVariantGroup: variantGroups.append(object, reference: reference)
+            case let object as XCVersionGroup: versionGroups.append(object, reference: reference)
 
             // everything else
             case let object as PBXBuildFile: buildFiles.append(object, reference: reference)
@@ -108,7 +109,6 @@ final public class PBXProj: Decodable {
             case let object as PBXNativeTarget: nativeTargets.append(object, reference: reference)
             case let object as PBXFileReference: fileReferences.append(object, reference: reference)
             case let object as PBXProject: projects.append(object, reference: reference)
-            case let object as XCVersionGroup: versionGroups.append(object, reference: reference)
             case let object as PBXReferenceProxy: referenceProxies.append(object, reference: reference)
             case let object as PBXRezBuildPhase: carbonResourcesBuildPhases.append(object, reference: reference)
             case let object as PBXBuildRule: buildRules.append(object, reference: reference)

--- a/Sources/xcproj/PBXProj.swift
+++ b/Sources/xcproj/PBXProj.swift
@@ -87,6 +87,10 @@ final public class PBXProj: Decodable {
         ///   - reference: object reference.
         public func addObject(_ object: PBXObject, reference: String) {
             switch object {
+            // subclass of PBXGroup; must be tested before PBXGroup
+            case let object as PBXVariantGroup: variantGroups.append(object, reference: reference)
+
+            // everything else
             case let object as PBXBuildFile: buildFiles.append(object, reference: reference)
             case let object as PBXAggregateTarget: aggregateTargets.append(object, reference: reference)
             case let object as PBXLegacyTarget: legacyTargets.append(object, reference: reference)
@@ -95,7 +99,6 @@ final public class PBXProj: Decodable {
             case let object as PBXGroup: groups.append(object, reference: reference)
             case let object as XCConfigurationList: configurationLists.append(object, reference: reference)
             case let object as XCBuildConfiguration: buildConfigurations.append(object, reference: reference)
-            case let object as PBXVariantGroup: variantGroups.append(object, reference: reference)
             case let object as PBXTargetDependency: targetDependencies.append(object, reference: reference)
             case let object as PBXSourcesBuildPhase: sourcesBuildPhases.append(object, reference: reference)
             case let object as PBXShellScriptBuildPhase: shellScriptBuildPhases.append(object, reference: reference)

--- a/Sources/xcproj/PBXProject+Deprecations.swift
+++ b/Sources/xcproj/PBXProject+Deprecations.swift
@@ -1,7 +1,7 @@
-extension PBXProject {
+public extension PBXProject {
 
     @available(*, deprecated, message: "Use projectRoots instead")
-    public var projectRoot: String {
+    var projectRoot: String {
         get {
             return projectRoots.first ?? ""
         }

--- a/Sources/xcproj/PBXVariantGroup+Deprecations.swift
+++ b/Sources/xcproj/PBXVariantGroup+Deprecations.swift
@@ -1,0 +1,21 @@
+public extension PBXVariantGroup {
+
+    /// Initializes the PBXVariantGroup with its values.
+    ///
+    /// - Parameters:
+    ///   - children: group children references.
+    ///   - path: path of the variant group
+    ///   - name: name of the variant group
+    ///   - sourceTree: the group source tree.
+    @available(*, deprecated, message: "use the initializer inherited from PBXGroup instead")
+    convenience init(children: [String] = [],
+                path: String? = nil,
+                name: String? = nil,
+                sourceTree: PBXSourceTree? = nil) {
+        self.init(children: children,
+                  sourceTree: sourceTree,
+                  name: name,
+                  path: path)
+    }
+
+}

--- a/Sources/xcproj/PBXVariantGroup.swift
+++ b/Sources/xcproj/PBXVariantGroup.swift
@@ -1,64 +1,15 @@
 import Foundation
 
 // This is the element for referencing localized resources.
-final public class PBXVariantGroup: PBXFileElement {
-
-    // MARK: - Attributes
-
-    /// The objects are a reference to a PBXFileElement element
-    public var children: [String]
-
-    // MARK: - Init
-
-    /// Initializes the PBXVariantGroup with its values.
-    ///
-    /// - Parameters:
-    ///   - children: group children references.
-    ///   - path: path of the variant group
-    ///   - name: name of the variant group
-    ///   - sourceTree: the group source tree.
-    public init(children: [String] = [],
-                path: String? = nil,
-                name: String? = nil,
-                sourceTree: PBXSourceTree? = nil) {
-        self.children = children
-        super.init(sourceTree: sourceTree, path: path, name: name)
-    }
-
-    // MARK: - Decodable
-
-    fileprivate enum CodingKeys: String, CodingKey {
-        case children
-        case reference
-    }
-
-    public required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.children = try container.decodeIfPresent([String].self, forKey: .children) ?? []
-        try super.init(from: decoder)
-    }
+final public class PBXVariantGroup: PBXGroup {
 
     // MARK: - Hashable
 
     public override func isEqual(to object: PBXObject) -> Bool {
-        guard let rhs = object as? PBXVariantGroup,
-            super.isEqual(to: rhs) else {
+        guard let rhs = object as? PBXVariantGroup else {
                 return false
         }
-        let lhs = self
-        return lhs.children == rhs.children &&
-        lhs.name == rhs.name &&
-        lhs.sourceTree == rhs.sourceTree
+        return super.isEqual(to: rhs)
     }
 
-    // MARK: - PlistSerializable
-
-    override func plistKeyAndValue(proj: PBXProj, reference: String) -> (key: CommentedString, value: PlistValue) {
-        var dictionary: [CommentedString: PlistValue] = super.plistKeyAndValue(proj: proj, reference: reference).value.dictionary ?? [:]
-        dictionary["isa"] = .string(CommentedString(PBXVariantGroup.isa))
-        dictionary["children"] = .array(children
-            .map({PlistValue.string(CommentedString($0, comment: proj.objects.fileName(fileReference: $0)))}))
-        return (key: CommentedString(reference, comment: name ?? path),
-                value: .dictionary(dictionary))
-    }
 }

--- a/Sources/xcproj/XCVersionGroup.swift
+++ b/Sources/xcproj/XCVersionGroup.swift
@@ -3,7 +3,7 @@ import PathKit
 
 /// Group that contains multiple files references to the different versions of a resource.
 /// Used to contain the different versions of a xcdatamodel
-final public class XCVersionGroup: PBXFileElement {
+final public class XCVersionGroup: PBXGroup {
 
     // MARK: - Attributes
 
@@ -13,21 +13,44 @@ final public class XCVersionGroup: PBXFileElement {
     /// Version group type.
     public let versionGroupType: String?
 
-    /// Children references.
-    public let children: [String]
-
     // MARK: - Init
 
+    /// Initializes the group with its attributes.
+    ///
+    /// - Parameters:
+    ///   - currentVersion: active version of the data model.
+    ///   - name: group name.
+    ///   - path: group relative path from `sourceTree`, if different than `name`.
+    ///   - sourceTree: group source tree.
+    ///   - versionGroupType: identifier of the group type.
+    ///   - children: group children.
+    ///   - includeInIndex: should the IDE index the files in the group?
+    ///   - wrapsLines: should the IDE wrap lines for files in the group?
+    ///   - usesTabs: group uses tabs.
+    ///   - indentWidth: the number of positions to indent blocks of code
+    ///   - tabWidth: the visual width of tab characters
     public init(currentVersion: String? = nil,
                 path: String? = nil,
                 name: String? = nil,
                 sourceTree: PBXSourceTree? = nil,
                 versionGroupType: String? = nil,
-                children: [String] = []) {
+                children: [String] = [],
+                includeInIndex: Bool? = nil,
+                wrapsLines: Bool? = nil,
+                usesTabs: Bool? = nil,
+                indentWidth: UInt? = nil,
+                tabWidth: UInt? = nil) {
         self.currentVersion = currentVersion
         self.versionGroupType = versionGroupType
-        self.children = children
-        super.init(sourceTree: sourceTree, path: path, name: name)
+        super.init(children: children,
+                   sourceTree: sourceTree,
+                   name: name,
+                   path: path,
+                   includeInIndex: includeInIndex,
+                   wrapsLines: wrapsLines,
+                   usesTabs: usesTabs,
+                   indentWidth: indentWidth,
+                   tabWidth: tabWidth)
     }
 
     public override func isEqual(to object: PBXObject) -> Bool {
@@ -37,8 +60,7 @@ final public class XCVersionGroup: PBXFileElement {
         }
         let lhs = self
         return lhs.currentVersion == rhs.currentVersion &&
-        lhs.versionGroupType == rhs.versionGroupType &&
-        lhs.children == rhs.children
+            lhs.versionGroupType == rhs.versionGroupType
     }
 
     // MARK: - Decodable
@@ -46,14 +68,12 @@ final public class XCVersionGroup: PBXFileElement {
     fileprivate enum CodingKeys: String, CodingKey {
         case currentVersion
         case versionGroupType
-        case children
     }
 
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.currentVersion = try container.decodeIfPresent(String.self, forKey: .currentVersion)
         self.versionGroupType = try container.decodeIfPresent(String.self, forKey: .versionGroupType)
-        self.children = try container.decodeIfPresent([String].self, forKey: .children) ?? []
         try super.init(from: decoder)
     }
 
@@ -65,11 +85,6 @@ final public class XCVersionGroup: PBXFileElement {
         if let versionGroupType = versionGroupType {
             dictionary["versionGroupType"] = .string(CommentedString(versionGroupType))
         }
-        dictionary["children"] = .array(children
-            .map({ fileReference in
-                let comment = proj.objects.fileName(fileReference: fileReference)
-                return .string(CommentedString(fileReference, comment: comment))
-            }))
         if let currentVersion = currentVersion {
             dictionary["currentVersion"] = .string(CommentedString(currentVersion, comment: proj.objects.fileName(fileReference: currentVersion)))
         }

--- a/Tests/xcprojTests/PBXFileElementSpec.swift
+++ b/Tests/xcprojTests/PBXFileElementSpec.swift
@@ -10,7 +10,8 @@ final class PBXFileElementSpec: XCTestCase {
         super.setUp()
         subject = PBXFileElement(sourceTree: .absolute,
                                  path: "path",
-                                 name: "name")
+                                 name: "name",
+                                 wrapsLines: true)
     }
 
     func test_isa_returnsTheCorrectValue() {
@@ -21,12 +22,14 @@ final class PBXFileElementSpec: XCTestCase {
         XCTAssertEqual(subject.sourceTree, .absolute)
         XCTAssertEqual(subject.path, "path")
         XCTAssertEqual(subject.name, "name")
+        XCTAssertEqual(subject.wrapsLines, true)
     }
 
     func test_equal_returnsTheCorrectValue() {
         let another = PBXFileElement(sourceTree: .absolute,
                                      path: "path",
-                                     name: "name")
+                                     name: "name",
+                                     wrapsLines: true)
         XCTAssertEqual(subject, another)
     }
 
@@ -34,7 +37,8 @@ final class PBXFileElementSpec: XCTestCase {
         return [
             "sourceTree": "absolute",
             "path": "path",
-            "name": "name"
+            "name": "name",
+            "wrapsLines": "1"
         ]
     }
 }

--- a/Tests/xcprojTests/PBXFileElementSpec.swift
+++ b/Tests/xcprojTests/PBXFileElementSpec.swift
@@ -11,6 +11,7 @@ final class PBXFileElementSpec: XCTestCase {
         subject = PBXFileElement(sourceTree: .absolute,
                                  path: "path",
                                  name: "name",
+                                 includeInIndex: false,
                                  wrapsLines: true)
     }
 
@@ -22,6 +23,7 @@ final class PBXFileElementSpec: XCTestCase {
         XCTAssertEqual(subject.sourceTree, .absolute)
         XCTAssertEqual(subject.path, "path")
         XCTAssertEqual(subject.name, "name")
+        XCTAssertEqual(subject.includeInIndex, false)
         XCTAssertEqual(subject.wrapsLines, true)
     }
 
@@ -29,6 +31,7 @@ final class PBXFileElementSpec: XCTestCase {
         let another = PBXFileElement(sourceTree: .absolute,
                                      path: "path",
                                      name: "name",
+                                     includeInIndex: false,
                                      wrapsLines: true)
         XCTAssertEqual(subject, another)
     }
@@ -38,6 +41,7 @@ final class PBXFileElementSpec: XCTestCase {
             "sourceTree": "absolute",
             "path": "path",
             "name": "name",
+            "includeInIndex": "0",
             "wrapsLines": "1"
         ]
     }

--- a/Tests/xcprojTests/PBXVariantGroupSpec.swift
+++ b/Tests/xcprojTests/PBXVariantGroupSpec.swift
@@ -9,8 +9,8 @@ final class PBXVariantGroupSpec: XCTestCase {
     override func setUp() {
         super.setUp()
         self.subject = PBXVariantGroup(children: ["child"],
-                                       name: "name",
-                                       sourceTree: .group)
+                                       sourceTree: .group,
+                                       name: "name")
     }
 
     func test_init_initializesTheModelWithTheCorrectAttributes() {
@@ -24,8 +24,8 @@ final class PBXVariantGroupSpec: XCTestCase {
     }
 
     func test_equals_returnsTheCorrectValue() {
-        let one = PBXVariantGroup(children: ["a"], name: "name", sourceTree: .group)
-        let another = PBXVariantGroup(children: ["a"], name: "name", sourceTree: .group)
+        let one = PBXVariantGroup(children: ["a"], sourceTree: .group, name: "name")
+        let another = PBXVariantGroup(children: ["a"], sourceTree: .group, name: "name")
         XCTAssertEqual(one, another)
     }
 


### PR DESCRIPTION
### Short description 📝
`PBXFileReference` and `PBXGroup` share many properties. Consolidate them in `PBXFileElement` and add additional unique properties to `PBXFileReference`.

### Solution 📦
Refactor the `PBXFileReference.includeInIndex`, `PBXGroup.usesTabs`, `PBXGroup.indentWidth`, `PBXGroup.tabWidth` properties so they're implemented in `PBXFileReference` so they can be shared by both subclasses. Add `PBXFileElement.wrapsLines`, `PBXFileReference.languageSpecificationIdentifier`, and `PBXFileReference.plistStructureDefinitionIdentifier`.

### Implementation 👩‍💻👨‍💻
- [x] Add `PBXFileElement.wrapsLines` property and parameters to the `PBXFileElement`, `PBXFileReference`, and `PBXGroup` initializers.
- [x] Move `includeInIndex` from `PBXFileReference` to `PBXFileElement` and add parameters to the `PBXFileElement` and `PBXGroup` initializers.
- [x] Move `usesTabs` from `PBXGroup` to `PBXFileElement` and add parameters to the `PBXFileElement` and `PBXFileReference` initializers.
- [x] Move `indentWidth` from `PBXGroup` to `PBXFileElement` and add parameters to the `PBXFileElement` and `PBXFileReference` initializers.
- [x] Move `tabWidth` from `PBXGroup` to `PBXFileElement` and add parameters to the `PBXFileElement` and `PBXFileReference` initializers.
- [x] Add `languageSpecificationIdentifier` and `plistStructureDefinitionIdentifier` to `PBXFileReference` and parameters to its initializer.
- [x] Simplify `PBXFileReference.isEqual(to:)` and `PBXGroup.isEqual(to:)` only compare properties the class implements.

This change does not remove any properties or initializer parameters on `PBXGroup` or `PBXFileElement`, so source compatibility should be maintained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/244)
<!-- Reviewable:end -->
