### PR TITLE
Fix returning full path for file in group without folder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Writes showEnvVarsInLog only when false https://github.com/xcodeswift/xcproj/pull/240 by @briantkelley
 - Writes `PBXProject.projectReferences` to the plist https://github.com/xcodeswift/xcproj/pull/242 by @briantkelley
 - Comment generation for `PBXProject`, `PBXTarget`, and `PBXVariantGroup` https://github.com/xcodeswift/xcproj/pull/243 by @briantkelley
+- `fullPath` now returns the path for a file inside a group without a folder https://github.com/xcodeswift/xcproj/pull/246 by @ileitch
 
 ## 4.1.0
 

--- a/Fixtures/iOS/Project.xcodeproj/project.pbxproj
+++ b/Fixtures/iOS/Project.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0403345F1F8F57CB0079CCF5 /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 0403345D1F8F57CB0079CCF5 /* Model.xcdatamodeld */; };
 		04D5C09F1F153824008A2F98 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 04D5C09E1F153824008A2F98 /* CoreData.framework */; };
 		04D5C0A31F153924008A2F98 /* Public.h in Headers */ = {isa = PBXBuildFile; fileRef = 04D5C0A01F153915008A2F98 /* Public.h */; };
 		04D5C0A41F153924008A2F98 /* Protected.h in Headers */ = {isa = PBXBuildFile; fileRef = 04D5C0A11F15391B008A2F98 /* Protected.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -18,6 +17,7 @@
 		23766C1D1EAA3484007A9026 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 23766C1C1EAA3484007A9026 /* Assets.xcassets */; };
 		23766C201EAA3484007A9026 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 23766C1E1EAA3484007A9026 /* LaunchScreen.storyboard */; };
 		23766C2B1EAA3484007A9026 /* iOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23766C2A1EAA3484007A9026 /* iOSTests.swift */; };
+		3CD1EADD205763E400DAEECB /* Model.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 3CD1EADB205763E400DAEECB /* Model.xcdatamodeld */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -54,7 +54,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0403345E1F8F57CB0079CCF5 /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 		04D5C09E1F153824008A2F98 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		04D5C0A01F153915008A2F98 /* Public.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Public.h; sourceTree = "<group>"; };
 		04D5C0A11F15391B008A2F98 /* Protected.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Protected.h; sourceTree = "<group>"; };
@@ -69,6 +68,7 @@
 		23766C261EAA3484007A9026 /* iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		23766C2A1EAA3484007A9026 /* iOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSTests.swift; sourceTree = "<group>"; };
 		23766C2C1EAA3484007A9026 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3CD1EADC205763E400DAEECB /* Model.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Model.xcdatamodel; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -120,6 +120,8 @@
 		23766C141EAA3484007A9026 /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				3CD1EADB205763E400DAEECB /* Model.xcdatamodeld */,
+				3CD1EAD92057638200DAEECB /* GroupWithoutFolder */,
 				23766C151EAA3484007A9026 /* AppDelegate.swift */,
 				23766C171EAA3484007A9026 /* ViewController.swift */,
 				23766C191EAA3484007A9026 /* Main.storyboard */,
@@ -129,7 +131,6 @@
 				04D5C0A01F153915008A2F98 /* Public.h */,
 				04D5C0A11F15391B008A2F98 /* Protected.h */,
 				04D5C0A21F153921008A2F98 /* Private.h */,
-				0403345D1F8F57CB0079CCF5 /* Model.xcdatamodeld */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -141,6 +142,13 @@
 				23766C2C1EAA3484007A9026 /* Info.plist */,
 			);
 			path = iOSTests;
+			sourceTree = "<group>";
+		};
+		3CD1EAD92057638200DAEECB /* GroupWithoutFolder */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = GroupWithoutFolder;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -283,7 +291,7 @@
 			files = (
 				23766C181EAA3484007A9026 /* ViewController.swift in Sources */,
 				23766C161EAA3484007A9026 /* AppDelegate.swift in Sources */,
-				0403345F1F8F57CB0079CCF5 /* Model.xcdatamodeld in Sources */,
+				3CD1EADD205763E400DAEECB /* Model.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -503,8 +511,15 @@
 /* End XCConfigurationList section */
 
 /* Begin XCVersionGroup section */
-		0403345D1F8F57CB0079CCF5 /* Model.xcdatamodeld */ = {
+		3CD1EADB205763E400DAEECB /* Model.xcdatamodeld */ = {
 			isa = XCVersionGroup;
+			children = (
+				3CD1EADC205763E400DAEECB /* Model.xcdatamodel */,
+			);
+			currentVersion = 3CD1EADC205763E400DAEECB /* Model.xcdatamodel */;
+			path = Model.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
 		};
 /* End XCVersionGroup section */
 	};

--- a/Sources/xcproj/PBXProjObjects+Helpers.swift
+++ b/Sources/xcproj/PBXProjObjects+Helpers.swift
@@ -182,7 +182,8 @@ public extension PBXProj.Objects {
         case .group?:
             guard let group = groups.first(where: { $0.value.children.contains(reference) }) else { return sourceRoot }
             guard let groupPath = fullPath(fileElement: group.value, reference: group.key, sourceRoot: sourceRoot) else { return nil }
-            return fileElement.path.flatMap({ Path($0, relativeTo: groupPath) })
+            guard let fileElementPath = fileElement.path else { return groupPath }
+            return Path(fileElementPath, relativeTo: groupPath)
         default:
             return nil
         }

--- a/Tests/xcprojTests/PBXProjSpec.swift
+++ b/Tests/xcprojTests/PBXProjSpec.swift
@@ -94,7 +94,7 @@ final class PBXProjIntegrationSpec: XCTestCase {
         XCTAssertEqual(proj.objects.aggregateTargets.count, 0)
         XCTAssertEqual(proj.objects.containerItemProxies.count, 1)
         XCTAssertEqual(proj.objects.copyFilesBuildPhases.count, 1)
-        XCTAssertEqual(proj.objects.groups.count, 5)
+        XCTAssertEqual(proj.objects.groups.count, 6)
         XCTAssertEqual(proj.objects.configurationLists.count, 3)
         XCTAssertEqual(proj.objects.buildConfigurations.count, 6)
         XCTAssertEqual(proj.objects.variantGroups.count, 2)

--- a/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
@@ -248,6 +248,13 @@ final class XcodeProjIntegrationSpec: XCTestCase {
         XCTAssertEqual(file.object.path, "../../newfile.swift")
         XCTAssertEqual(fullFilePath, filePath)
 
+        let groupWithoutFolder = proj.objects.group(named: "GroupWithoutFolder", inGroup: iOSGroup)!.object
+        file = try proj.objects.addFile(at: filePath, toGroup: groupWithoutFolder, sourceTree: .group, sourceRoot: sourceRoot)
+        fullFilePath = proj.objects.fullPath(fileElement: file.object, reference: file.reference, sourceRoot: sourceRoot)
+
+        XCTAssertEqual(file.object.path, "../../newfile.swift")
+        XCTAssertEqual(fullFilePath, filePath)
+
         proj = projectiOS()!.pbxproj
         iOSGroup = proj.objects.group(named: "iOS", inGroup: proj.rootGroup)!.object
         file = try proj.objects.addFile(at: filePath, toGroup: iOSGroup, sourceTree: .sourceRoot, sourceRoot: sourceRoot)


### PR DESCRIPTION
`fullPath` currently returns `nil` for files that exist inside a group without a folder. This PR fixes it to return the correct path to the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/246)
<!-- Reviewable:end -->
