### PR TITLE
Target Xcode 9.3

### DIFF
--- a/Fixtures/WithoutWorkspace/WithoutWorkspace.xcodeproj/xcshareddata/xcschemes/WithoutWorkspace-Package.xcscheme
+++ b/Fixtures/WithoutWorkspace/WithoutWorkspace.xcodeproj/xcshareddata/xcschemes/WithoutWorkspace-Package.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -47,7 +46,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
+++ b/Fixtures/iOS/Project.xcodeproj/xcshareddata/xcschemes/iOS.xcscheme
@@ -44,7 +44,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <PreActions>
          <ExecutionAction
@@ -119,7 +118,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/xcproj/AEXML+XcodeFormat.swift
+++ b/Sources/xcproj/AEXML+XcodeFormat.swift
@@ -32,8 +32,8 @@ let attributesOrder: [String: [String]] = [
         "selectedLauncherIdentifier",
         "language",
         "region",
-        "shouldUseLaunchSchemeArgsEnv",
-        "codeCoverageEnabled"
+        "codeCoverageEnabled",
+        "shouldUseLaunchSchemeArgsEnv"
     ],
     "LaunchAction": [
         "buildConfiguration",

--- a/Sources/xcproj/XCScheme.swift
+++ b/Sources/xcproj/XCScheme.swift
@@ -490,7 +490,6 @@ final public class XCScheme {
                                        attributes: ["buildConfiguration": buildConfiguration,
                                                     "selectedDebuggerIdentifier": selectedDebuggerIdentifier,
                                                     "selectedLauncherIdentifier": selectedLauncherIdentifier,
-                                                    "language": language ?? "",
                                                     "launchStyle": launchStyle.rawValue,
                                                     "useCustomWorkingDirectory": useCustomWorkingDirectory.xmlString,
                                                     "ignoresPersistentStateOnLaunch": ignoresPersistentStateOnLaunch.xmlString,
@@ -517,6 +516,10 @@ final public class XCScheme {
 
             if let environmentVariables = environmentVariables {
                 element.addChild(EnvironmentVariable.xmlElement(from: environmentVariables))
+            }
+
+            if let language = language {
+                element.attributes["language"] = language
             }
 
             if let region = region {
@@ -722,7 +725,9 @@ final public class XCScheme {
             attributes["buildConfiguration"] = buildConfiguration
             attributes["selectedDebuggerIdentifier"] = selectedDebuggerIdentifier
             attributes["selectedLauncherIdentifier"] = selectedLauncherIdentifier
-            attributes["language"] = language ?? ""
+            if let language = language {
+              attributes["language"] = language
+            }
             attributes["region"] = region
             attributes["shouldUseLaunchSchemeArgsEnv"] = shouldUseLaunchSchemeArgsEnv.xmlString
             if codeCoverageEnabled {


### PR DESCRIPTION
**Opening this for early feedback**

There are probably some more things to do, and I need to fix the tests (would love some pointers on fixing the tests 😄)

This ties into yonaskolb/XcodeGen#284

### Short description 📝
> Updates output to match what Xcode 9.3 would have produced.

### Solution 📦
> Changed the ordering of `codeCoverageEnabled` & `shouldUseLaunchSchemeArgsEnv`. Only wrote `language` if actually had a value.

### Implementation 👩‍💻👨‍💻
- [x] Changed the ordering of `codeCoverageEnabled` & `shouldUseLaunchSchemeArgsEnv`.
- [x] Modified `TestAction` and `LaunchAction` to only print `language` if set.

### GIF
![](https://media.giphy.com/media/5tvJS6ZZslR9nBYxUA/giphy.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xcodeswift/xcproj/247)
<!-- Reviewable:end -->
