### PR TITLE
Strip Trailing Semicolon in xcconfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Fixed
+- XCConfig parser strips the trailing semicolon from a configuration value https://github.com/xcodeswift/xcproj/pull/250 by @briantkelley
+
 ## 4.3.0
 
 ### Added

--- a/Sources/xcproj/XCConfig.swift
+++ b/Sources/xcproj/XCConfig.swift
@@ -105,7 +105,7 @@ final class XCConfigParser {
     // swiftlint:disable:next force_try
     private static var includeRegex = try! NSRegularExpression(pattern: "#include\\s+\"(.+\\.xcconfig)\"", options: .caseInsensitive)
     // swiftlint:disable:next force_try
-    private static var settingRegex = try! NSRegularExpression(pattern: "^([a-zA-Z0-9_\\[\\]=\\*~]+)\\s*=\\s*(\"?.*\"?)", options: [])
+    private static var settingRegex = try! NSRegularExpression(pattern: "^([a-zA-Z0-9_\\[\\]=\\*~]+)\\s*=\\s*(\"?.*?\"?)\\s*(?:;\\s*)?$", options: [])
 }
 
 // MARK: - XCConfig Extension (Equatable)

--- a/Tests/xcprojTests/XCConfigSpec.swift
+++ b/Tests/xcprojTests/XCConfigSpec.swift
@@ -30,39 +30,41 @@ final class XCConfigSpec: XCTestCase {
     }
 
     func test_xcconfig_settingRegex() {
-        do {
-            let line = "A = a"
-            let (key, value) = XCConfigParser.settingFrom(line: line)!
-            XCTAssertEqual("A", key)
-            XCTAssertEqual("a", value)
-        }
-        do {
-            let line = "B=b"
-            let (key, value) = XCConfigParser.settingFrom(line: line)!
-            XCTAssertEqual("B", key)
-            XCTAssertEqual("b", value)
-        }
-        do {
-            let line = "B=\"b=b=b=\""
-            let (key, value) = XCConfigParser.settingFrom(line: line)!
-            XCTAssertEqual("B", key)
-            XCTAssertEqual("\"b=b=b=\"", value)
-        }
-        do {
-            let line = "B=\"b\\\"b\""
-            let (key, value) = XCConfigParser.settingFrom(line: line)!
-            XCTAssertEqual("B", key)
-            XCTAssertEqual("\"b\\\"b\"", value)
-        }
-        do {
-            let line = "// A = a"
-            XCTAssertNil(XCConfigParser.settingFrom(line: line))
-        }
-        do {
-            let line = "A[sdk=iphoneos*] = a"
-            let (key, value) = XCConfigParser.settingFrom(line: line)!
-            XCTAssertEqual("A[sdk=iphoneos*]", key)
-            XCTAssertEqual("a", value)
+        for suffix in ["", ";", " ;", "; ", " ; "] {
+            do {
+                let line = "A = a" + suffix
+                let (key, value) = XCConfigParser.settingFrom(line: line)!
+                XCTAssertEqual("A", key)
+                XCTAssertEqual("a", value)
+            }
+            do {
+                let line = "B=b" + suffix
+                let (key, value) = XCConfigParser.settingFrom(line: line)!
+                XCTAssertEqual("B", key)
+                XCTAssertEqual("b", value)
+            }
+            do {
+                let line = "B=\"b=b=b=\"" + suffix
+                let (key, value) = XCConfigParser.settingFrom(line: line)!
+                XCTAssertEqual("B", key)
+                XCTAssertEqual("\"b=b=b=\"", value)
+            }
+            do {
+                let line = "B=\"b\\\"b\"" + suffix
+                let (key, value) = XCConfigParser.settingFrom(line: line)!
+                XCTAssertEqual("B", key)
+                XCTAssertEqual("\"b\\\"b\"", value)
+            }
+            do {
+                let line = "// A = a" + suffix
+                XCTAssertNil(XCConfigParser.settingFrom(line: line))
+            }
+            do {
+                let line = "A[sdk=iphoneos*] = a" + suffix
+                let (key, value) = XCConfigParser.settingFrom(line: line)!
+                XCTAssertEqual("A[sdk=iphoneos*]", key)
+                XCTAssertEqual("a", value)
+            }
         }
     }
 


### PR DESCRIPTION
### Short description 📝
If a configuration setting ends in a semicolon, Xcode strips it from the value. Update xcproj to do the same.

### Solution 📦
Update the `settingRegex` regular expression to not capture a trailing semicolon (and trailing whitespace) but still capture all of the value portion of the string.