### PR TITLE
Fix fullPath for files that reside within a variant group.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - XCConfig parser strips the trailing semicolon from a configuration value https://github.com/xcodeswift/xcproj/pull/250 by @briantkelley
+- `fullPath(fileElement:reference:sourceRoot:)` now returns the correct path for files that exist within a variant group https://github.com/xcodeswift/xcproj/pull/255 by @ileitch
 
 ## 4.3.0
 

--- a/Sources/xcproj/PBXProjObjects+Helpers.swift
+++ b/Sources/xcproj/PBXProjObjects+Helpers.swift
@@ -182,14 +182,14 @@ public extension PBXProj.Objects {
         case .group?:
             guard let group = groups.first(where: { $0.value.children.contains(reference) }) else { return sourceRoot }
             guard let groupPath = fullPath(fileElement: group.value, reference: group.key, sourceRoot: sourceRoot) else { return nil }
-            guard let filePath = fileElement is PBXVariantGroup ? baseVarientGroupPath(for: reference) : fileElement.path else { return groupPath }
+            guard let filePath = fileElement is PBXVariantGroup ? baseVariantGroupPath(for: reference) : fileElement.path else { return groupPath }
             return Path(filePath, relativeTo: groupPath)
         default:
             return nil
         }
     }
 
-    private func baseVarientGroupPath(for reference: String) -> String? {
+    private func baseVariantGroupPath(for reference: String) -> String? {
       guard let variantGroup = variantGroups[reference],
         let baseReference = variantGroup.children.first(where: { fileReferences[$0]?.name == "Base" }),
         let baseVariant = fileReferences[baseReference] else { return nil }

--- a/Sources/xcproj/PBXProjObjects+Helpers.swift
+++ b/Sources/xcproj/PBXProjObjects+Helpers.swift
@@ -182,13 +182,20 @@ public extension PBXProj.Objects {
         case .group?:
             guard let group = groups.first(where: { $0.value.children.contains(reference) }) else { return sourceRoot }
             guard let groupPath = fullPath(fileElement: group.value, reference: group.key, sourceRoot: sourceRoot) else { return nil }
-            guard let fileElementPath = fileElement.path else { return groupPath }
-            return Path(fileElementPath, relativeTo: groupPath)
+            guard let filePath = fileElement is PBXVariantGroup ? baseVarientGroupPath(for: reference) : fileElement.path else { return groupPath }
+            return Path(filePath, relativeTo: groupPath)
         default:
             return nil
         }
     }
 
+    private func baseVarientGroupPath(for reference: String) -> String? {
+      guard let variantGroup = variantGroups[reference],
+        let baseReference = variantGroup.children.first(where: { fileReferences[$0]?.name == "Base" }),
+        let baseVariant = fileReferences[baseReference] else { return nil }
+
+      return baseVariant.path
+    }
 }
 
 public struct GroupAddingOptions: OptionSet {
@@ -244,7 +251,7 @@ extension Path {
 // MARK: - PBXProj.Objects Extension (Internal)
 
 extension PBXProj.Objects {
-    
+
     /// Returns the file name from a build file reference.
     ///
     /// - Parameter buildFileReference: file reference.
@@ -256,7 +263,7 @@ extension PBXProj.Objects {
         }
         return fileName(fileReference: fileReference)
     }
-    
+
     /// Returns the file name from a file reference.
     ///
     /// - Parameter fileReference: file reference.
@@ -267,7 +274,7 @@ extension PBXProj.Objects {
         }
         return fileElement.name ?? fileElement.path
     }
-    
+
     /// Returns the configNamefile reference.
     ///
     /// - Parameter configReference: reference of the XCBuildConfiguration.
@@ -275,7 +282,7 @@ extension PBXProj.Objects {
     func configName(configReference: String) -> String? {
         return buildConfigurations[configReference]?.name
     }
-    
+
     /// Returns the build phase a file is in.
     ///
     /// - Parameter reference: reference of the file whose type will be returned.
@@ -296,7 +303,7 @@ extension PBXProj.Objects {
         }
         return nil
     }
-    
+
     /// Returns the build phase type from its reference.
     ///
     /// - Parameter reference: build phase reference.
@@ -319,7 +326,7 @@ extension PBXProj.Objects {
         }
         return nil
     }
-    
+
     /// Get the build phase name given its reference (mostly used for comments).
     ///
     /// - Parameter buildPhaseReference: build phase reference.
@@ -342,7 +349,7 @@ extension PBXProj.Objects {
         }
         return nil
     }
-    
+
     /// Returns the build phase name a file is in (mostly used for comments).
     ///
     /// - Parameter reference: reference of the file whose type name will be returned.
@@ -356,7 +363,7 @@ extension PBXProj.Objects {
             return type?.rawValue
         }
     }
-    
+
     /// Returns the object with the given configuration list (project or target)
     ///
     /// - Parameter reference: configuration list reference.
@@ -367,5 +374,5 @@ extension PBXProj.Objects {
             aggregateTargets.first(where: { $0.value.buildConfigurationList == reference}).flatMap(ObjectReference.init) ??
             legacyTargets.first(where: { $0.value.buildConfigurationList == reference}).flatMap(ObjectReference.init)
     }
-    
+
 }

--- a/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
+++ b/Tests/xcprojTests/XcodeProjIntegrationSpec.swift
@@ -22,7 +22,7 @@ final class XcodeProjIntegrationSpec: XCTestCase {
                   initModel: { try? XcodeProj(path: $0) },
                   modify: { $0 })
     }
-    
+
     func test_init_usesAnEmptyWorkspace_whenItsMissing() throws {
         let got = try projectWithoutWorkspace()
         XCTAssertEqual(got.workspace.data.children.count, 1)
@@ -50,9 +50,9 @@ final class XcodeProjIntegrationSpec: XCTestCase {
         for path in pathsToProjectsToTest {
             let rawProj: String = try (path + "project.pbxproj").read()
             let proj = try XcodeProj(path: path)
-            
+
             let output = proj.pbxproj.encode()
-            
+
             XCTAssertEqual(output, rawProj)
         }
     }
@@ -100,19 +100,19 @@ final class XcodeProjIntegrationSpec: XCTestCase {
 
     func test_add_new_group() throws {
         let project = projectiOS()!.pbxproj
-        
+
         let groups = project.objects.addGroup(named: "Group", to: project.rootGroup)
         let groupRef = XCTAssertNotNilAndUnwrap(groups.first)
-        
+
         let group = groupRef.object
         XCTAssertEqual(group.name, "Group")
         XCTAssertEqual(group.path, "Group")
-        
+
         let reference = groupRef.reference
         XCTAssertNotNil(project.rootGroup.children.index(of: reference))
         XCTAssertEqual(project.objects.groups[reference], group)
     }
-    
+
     func test_add_new_group_without_folder_has_nil_path() {
         let project = projectiOS()!.pbxproj
         let groups = project.objects.addGroup(named: "Group", to: project.rootGroup, options: [.withoutFolder])
@@ -127,7 +127,7 @@ final class XcodeProjIntegrationSpec: XCTestCase {
         let existingGroups = project.objects.addGroup(named: "Group", to: project.rootGroup)
         XCTAssertEqual(groups[0], existingGroups[0])
     }
-    
+
     func test_add_nested_group() throws {
         let project = projectiOS()!
         let groups = project.pbxproj.objects.addGroup(named: "New/Group", to: project.pbxproj.rootGroup)
@@ -165,7 +165,7 @@ final class XcodeProjIntegrationSpec: XCTestCase {
                                             explicitFileType: "sourcecode.swift",
                                             lastKnownFileType: "sourcecode.swift",
                                             path: "../../newfile.swift")
-        
+
         XCTAssertEqual(proj.objects.fileReferences[file.reference], file.object)
         XCTAssertEqual(file.object, expectedFile)
         XCTAssertNotNil(iOSGroup.object.children.index(of: file.reference))
@@ -174,38 +174,38 @@ final class XcodeProjIntegrationSpec: XCTestCase {
 
         XCTAssertTrue(file == existingFile)
     }
-    
+
     func test_add_new_dynamic_framework() throws {
         let proj = projectiOS()!.pbxproj
         let filePath = fixturesPath() + "dummy.framework"
-        
+
         let iOSGroup = proj.objects.group(named: "iOS", inGroup: proj.rootGroup)!
         let file = try proj.objects.addFile(at: filePath,
                                             toGroup: iOSGroup.object,
                                             sourceRoot: fixtureiOSSourcePath())
-        
+
         let expectedFile = PBXFileReference(sourceTree: .group,
                                             name: "dummy.framework",
                                             explicitFileType: "wrapper.framework",
                                             lastKnownFileType: "wrapper.framework",
                                             path: "../../dummy.framework")
-        
-        
+
+
         XCTAssertEqual(proj.objects.fileReferences[file.reference], file.object)
         XCTAssertEqual(file.object, expectedFile)
         XCTAssertNotNil(iOSGroup.object.children.index(of: file.reference))
     }
-    
+
     func test_add_existing_file_returns_existing_object() throws {
         let proj = projectiOS()!.pbxproj
         let filePath = fixturesPath() + "newfile.swift"
         let iOSGroup = proj.objects.group(named: "iOS", inGroup: proj.rootGroup)!.object
-        
+
         let file = try proj.objects.addFile(at: filePath, toGroup: iOSGroup, sourceRoot: fixtureiOSSourcePath())
         let existingFile = try proj.objects.addFile(at: filePath, toGroup: proj.rootGroup, sourceRoot: fixtureiOSSourcePath())
         XCTAssertTrue(file == existingFile)
     }
-    
+
     func test_add_nonexisting_file_throws() {
         let proj = projectiOS()!.pbxproj
         let filePath = fixturesPath() + "nonexisting.swift"
@@ -270,6 +270,11 @@ final class XcodeProjIntegrationSpec: XCTestCase {
 
         XCTAssertEqual(file.object.path, filePath.string)
         XCTAssertEqual(fullFilePath, filePath)
+
+        let mainStoryboard = proj.objects.variantGroups.first { $0.value.name == "Main.storyboard" }!
+        let mainStoryboardfullPath = proj.objects.fullPath(fileElement: mainStoryboard.value, reference: mainStoryboard.key, sourceRoot: sourceRoot)
+
+        XCTAssertEqual(mainStoryboardfullPath, fixturesPath() + "iOS/iOS/Base.lproj/Main.storyboard")
     }
 
     func test_path_relativeToPath() {
@@ -305,19 +310,19 @@ final class XcodeProjIntegrationSpec: XCTestCase {
     private func fixtureWithoutWorkspaceProjectPath() -> Path {
         return fixturesPath() + "WithoutWorkspace/WithoutWorkspace.xcodeproj"
     }
-    
+
     private func fixtureiOSProjectPath() -> Path {
         return fixturesPath() + "iOS/Project.xcodeproj"
     }
-    
+
     private func fixtureiOSSourcePath() -> Path {
         return fixturesPath() + "iOS"
     }
-    
+
     private func projectiOS() -> XcodeProj? {
         return try? XcodeProj(path: fixtureiOSProjectPath())
     }
-    
+
     private func projectWithoutWorkspace() throws -> XcodeProj {
         return try XcodeProj(path: fixtureWithoutWorkspaceProjectPath())
     }


### PR DESCRIPTION
Fix `fullPath` for files that reside in a `Base` variant group, e.g a `xib` that lives inside `Base.lproj`.
