### PR TITLE
Add Swiftlint to Danger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version
 
+### Added
+- Danger check that reports Swiftlint results https://github.com/xcodeswift/xcproj/pull/257 by @pepibumur.
+
 ### Fixed
 - XCConfig parser strips the trailing semicolon from a configuration value https://github.com/xcodeswift/xcproj/pull/250 by @briantkelley
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,10 @@
 require_relative "Danger/carthage"
 
+# Organization Dangerfile
 danger.import_dangerfile(gem: 'danger-xcodeswift')
 
+# Carthage
 Danger::Plugins::Carthage.new(self).execute
+
+# Swiftlint
+swiftlint.lint_files

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem "cocoapods"
 gem 'danger-xcodeswift', :git => "https://github.com/xcodeswift/danger", require: false
 gem "git"
 gem "rspec"
+gem 'danger-swiftlint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   colorize
+  danger-swiftlint
   danger-xcodeswift!
   git
   jazzy


### PR DESCRIPTION
### Short description 📝
Adds a new check to Danger that runs Swiftlint and reports any issues back to the PR.

### Implementation 👩‍💻👨‍💻
- [x] Add gem to the `Gemfile`.
- [x] Update `Dangerfile`.