### PR TITLE
Enable codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,4 @@ script:
 - bundle exec rake ci
 after_success:
 - bundle exec rake deploy_to_integration
+- bash <(curl -s https://codecov.io/bash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - XCConfig parser strips the trailing semicolon from a configuration value https://github.com/xcodeswift/xcproj/pull/250 by @briantkelley
 
+### Added
+- Test coverage reports https://github.com/xcodeswift/xcproj/pull/258 by @pepibumur
+
 ## 4.3.0
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem "cocoapods"
 gem 'danger-xcodeswift', :git => "https://github.com/xcodeswift/danger", require: false
 gem "git"
 gem "rspec"
+gem "xcpretty"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 <a href="https://opensource.org/licenses/MIT">
   <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License" />
 </a>
+<a href="https://codecov.io/gh/xcodeswift/xcproj">
+  <img src="https://codecov.io/gh/xcodeswift/xcproj/branch/master/graph/badge.svg" />
+</a>
 
 xcproj is a library written in Swift for parsing and working with Xcode projects. It's heavily inspired in [CocoaPods XcodeProj](https://github.com/CocoaPods/Xcodeproj) and [xcode](https://www.npmjs.com/package/xcode).
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ def git
 end
 
 def generate_docs
-  print "Executing tests"
+  print "Generating docs"
   sh "swift package generate-xcodeproj"
   sh "jazzy --clean --sdk macosx --xcodebuild-arguments -project,xcproj.xcodeproj,-scheme,xcproj-Package --skip-undocumented"
 end
@@ -42,7 +42,7 @@ task :carthage do
 end
 
 def test_swift
-  sh "swift test --filter xcprojTests"
+  sh "xcodebuild -project xcproj.xcodeproj -scheme xcproj-Package -only-testing:xcprojTests -config Debug test -enableCodeCoverage YES"
 end
 
 def test_swift_integration

--- a/Rakefile
+++ b/Rakefile
@@ -103,6 +103,8 @@ end
 
 desc "Executes all the validation steps for CI"
 task :ci do
+  print "Generate Xcode project"
+  sh "swift package generate-xcodeproj"
   print "Linting project"
   sh "swiftlint" if is_macos
   print "CocoaPods linting"


### PR DESCRIPTION
### Short description 📝
Adds test coverage metrics to the project using Codecov. Every new PR will get a report comment that indicates whether the test coverage improved or it requires some attention.

### Implementation 👩‍💻👨‍💻
- [x] Setup Travis-CI with the Codecov token.
- [x] Update `Rakefile` task to run the tests with the *"gather test coverage data"* flag enabled.
- [x] Update `.travis.yml` to run an after-success step that reports the test coverage data to Codecov.